### PR TITLE
feature #2 : 위치정보 추적 권한 요청

### DIFF
--- a/Outline/Outline.xcodeproj/project.pbxproj
+++ b/Outline/Outline.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F05C97172ADA879100D5D959 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05C97162ADA879100D5D959 /* LocationManager.swift */; };
+		F05C97192ADA87B800D5D959 /* LocationAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05C97182ADA87B800D5D959 /* LocationAuthorizationView.swift */; };
 		F0AC8A9D2AD94C1F0061612C /* OutlineApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AC8A9C2AD94C1F0061612C /* OutlineApp.swift */; };
 		F0AC8A9F2AD94C1F0061612C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AC8A9E2AD94C1F0061612C /* ContentView.swift */; };
 		F0AC8AA12AD94C200061612C /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F0AC8AA02AD94C200061612C /* Color.xcassets */; };
@@ -60,6 +62,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F05C97162ADA879100D5D959 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		F05C97182ADA87B800D5D959 /* LocationAuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationAuthorizationView.swift; sourceTree = "<group>"; };
 		F0AC8A992AD94C1F0061612C /* Outline.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Outline.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F0AC8A9C2AD94C1F0061612C /* OutlineApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineApp.swift; sourceTree = "<group>"; };
 		F0AC8A9E2AD94C1F0061612C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -108,6 +112,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		F05C97152ADA877A00D5D959 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				F05C97162ADA879100D5D959 /* LocationManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
 		F0AC8A902AD94C1F0061612C = {
 			isa = PBXGroup;
 			children = (
@@ -167,6 +179,7 @@
 			isa = PBXGroup;
 			children = (
 				F0AC8B002AD964AE0061612C /* View.swift */,
+				F05C97182ADA87B800D5D959 /* LocationAuthorizationView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -187,6 +200,7 @@
 				F0AC8AFA2AD963600061612C /* View */,
 				F0AC8AFB2AD963690061612C /* ViewModel */,
 				F0AC8B052AD965290061612C /* Model */,
+				F05C97152ADA877A00D5D959 /* Manager */,
 				F0AC8B082AD965470061612C /* DesignSystem */,
 			);
 			path = Source;
@@ -474,7 +488,9 @@
 			files = (
 				F0AC8B382AD96AE10061612C /* ViewExtension.swift in Sources */,
 				F0AC8B112AD965A70061612C /* Modifier.swift in Sources */,
+				F05C97172ADA879100D5D959 /* LocationManager.swift in Sources */,
 				F0AC8B072AD965390061612C /* Model.swift in Sources */,
+				F05C97192ADA87B800D5D959 /* LocationAuthorizationView.swift in Sources */,
 				F0AC8B0D2AD965950061612C /* Component.swift in Sources */,
 				F0AC8B0F2AD9659D0061612C /* ColorExtension.swift in Sources */,
 				F0AC8B012AD964AE0061612C /* View.swift in Sources */,
@@ -701,6 +717,8 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Outline;
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "당신의 위치는 러닝을 기록하는데 사용됩니다. 운동 중에 백그라운드에서도 위치 서비스를 사용합니다.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "당신의 위치는 러닝을 기록하는데 사용됩니다. 운동 중에 백그라운드에서도 위치 서비스를 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -735,6 +753,8 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Outline;
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "당신의 위치는 러닝을 기록하는데 사용됩니다. 운동 중에 백그라운드에서도 위치 서비스를 사용합니다.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "당신의 위치는 러닝을 기록하는데 사용됩니다. 운동 중에 백그라운드에서도 위치 서비스를 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Outline/Outline/Source/Manager/LocationManager.swift
+++ b/Outline/Outline/Source/Manager/LocationManager.swift
@@ -1,0 +1,56 @@
+//
+//  LocationManager.swift
+//  Outline
+//
+//  Created by Hyunjun Kim on 10/14/23.
+//
+
+import MapKit
+
+final class LocationManager: NSObject, CLLocationManagerDelegate, ObservableObject {
+    
+    @Published var isAuthorized = false
+    @Published var isNext = false
+    
+    var locationManager: CLLocationManager?
+    
+    func checkIfLocationServicesEnabled() {
+        locationManager = CLLocationManager()
+        locationManager?.delegate = self
+        locationManager?.desiredAccuracy = kCLLocationAccuracyBest
+    }
+    
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        checkLocationAuthorization()
+        print(isNext.description)
+        print(isAuthorized.description)
+    }
+    
+    private func checkLocationAuthorization() {
+        guard let locationManager = locationManager else { return }
+        
+        switch locationManager.authorizationStatus {
+            
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+            print("not determined")
+            isAuthorized = false
+        case .restricted, .denied:
+            print("denied")
+            isAuthorized = false
+            isNext = true
+        case .authorizedAlways, .authorizedWhenInUse:
+            print("authorized")
+            isAuthorized = true
+            isNext = true
+        @unknown default:
+            break
+        }
+    }
+    
+    func openAppSetting() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+}

--- a/Outline/Outline/Source/Manager/LocationManager.swift
+++ b/Outline/Outline/Source/Manager/LocationManager.swift
@@ -22,8 +22,6 @@ final class LocationManager: NSObject, CLLocationManagerDelegate, ObservableObje
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         checkLocationAuthorization()
-        print(isNext.description)
-        print(isAuthorized.description)
     }
     
     private func checkLocationAuthorization() {
@@ -33,14 +31,11 @@ final class LocationManager: NSObject, CLLocationManagerDelegate, ObservableObje
             
         case .notDetermined:
             locationManager.requestWhenInUseAuthorization()
-            print("not determined")
             isAuthorized = false
         case .restricted, .denied:
-            print("denied")
             isAuthorized = false
             isNext = true
         case .authorizedAlways, .authorizedWhenInUse:
-            print("authorized")
             isAuthorized = true
             isNext = true
         @unknown default:

--- a/Outline/Outline/Source/Manager/LocationManager.swift
+++ b/Outline/Outline/Source/Manager/LocationManager.swift
@@ -14,17 +14,17 @@ final class LocationManager: NSObject, CLLocationManagerDelegate, ObservableObje
     
     var locationManager: CLLocationManager?
     
-    func checkIfLocationServicesEnabled() {
+    func checkLocationAuthorization() {
         locationManager = CLLocationManager()
         locationManager?.delegate = self
         locationManager?.desiredAccuracy = kCLLocationAccuracyBest
     }
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        checkLocationAuthorization()
+        checkLocationAuthorizationStatus()
     }
     
-    private func checkLocationAuthorization() {
+    private func checkLocationAuthorizationStatus() {
         guard let locationManager = locationManager else { return }
         
         switch locationManager.authorizationStatus {

--- a/Outline/Outline/Source/View/LocationAuthorizationView.swift
+++ b/Outline/Outline/Source/View/LocationAuthorizationView.swift
@@ -1,0 +1,29 @@
+//
+//  LocationAuthorizationView.swift
+//  Outline
+//
+//  Created by Hyunjun Kim on 10/14/23.
+//
+
+import SwiftUI
+
+struct LocationAuthorizationView: View {
+    
+    @StateObject var locationManager = LocationManager()
+    
+    var body: some View {
+        VStack {
+            Text("정확한 경로 정보를 제공하기 위해\n위치 허용이 필요합니다.")
+                .multilineTextAlignment(.center)
+                .padding(.top, 100)
+                .onAppear {
+                    locationManager.checkIfLocationServicesEnabled()
+                }
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    LocationAuthorizationView()
+}

--- a/Outline/Outline/Source/View/LocationAuthorizationView.swift
+++ b/Outline/Outline/Source/View/LocationAuthorizationView.swift
@@ -17,7 +17,7 @@ struct LocationAuthorizationView: View {
                 .multilineTextAlignment(.center)
                 .padding(.top, 100)
                 .onAppear {
-                    locationManager.checkIfLocationServicesEnabled()
+                    locationManager.checkLocationAuthorization()
                 }
             Spacer()
         }


### PR DESCRIPTION
## 📌 Summary
- #2 
- 위치정보 추적 권한 `LocationManager` 를 생성하였습니다.

<br>

## ✨ Description
- info 수정
  - Privacy - Location 관련 설정 수정
<img width="825" alt="스크린샷 2023-10-14 오후 8 17 32" src="https://github.com/BostonGosari/Outline/assets/120548537/86d692b4-afc2-4e92-b71c-f25be138bab0">

- `Manager` 파일 생성
- 유저의 실시간 위치설정에 대응하기 위해 `LocationManager` 생성
   - 다음으로 넘어가기 위한 `isNext` 변수
   - 권한상태를 확인하기 위한 `isAuthorized` 변수를 두었습니다. `locationManagerDidChangeAuthorization` 함수로 실시간 권한 변경이 되었을때만 `isAuthorized` 가 변경되게 하였습니다.
```swift
final class LocationManager: NSObject, CLLocationManagerDelegate, ObservableObject {
    @Published var isAuthorized = false
    @Published var isNext = false
}
```
- 권한 상태를 체크하여 `.notDetermined` 일때 `locationManager.requestWhenInUseAuthorization()` 메서드를 호출합니다.
```swift
    private func checkLocationAuthorization() {
        guard let locationManager = locationManager else { return }
        
        switch locationManager.authorizationStatus {
            
        case .notDetermined:
            locationManager.requestWhenInUseAuthorization()
            isAuthorized = false
        case .restricted, .denied:
            isAuthorized = false
            isNext = true
        case .authorizedAlways, .authorizedWhenInUse:
            isAuthorized = true
            isNext = true
        @unknown default:
            break
        }
    }
```
- `openAppSetting()` 의 경우 추후 `isAuthorized` 가 `false` 일때 alert 과함께 자동으로 시스템 설정으로 넘어가기 위한 함수입니다.
   - 위 플로우는 **Nike Run Club** 앱을 참고했습니다. `denied` 되었을때 다시 `Request` 를 하지 못하는 듯 합니다.

|비고|위치정보 권한 없을 때 시작버튼 누를시|설정뷰로 이동|
|:--:|:--:|:--:|
|스크린샷|<img src = "https://github.com/BostonGosari/Outline/assets/120548537/d17be44c-0a15-4a6e-a666-60a08fcaa160" width ="250">|<img src = "https://github.com/BostonGosari/Outline/assets/120548537/743716da-0385-46e0-86c2-32011350472e" width ="250">|

```swift
    func openAppSetting() {
        if let url = URL(string: UIApplication.openSettingsURLString) {
            UIApplication.shared.open(url, options: [:], completionHandler: nil)
        }
    }
```
<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|권한 요청 뷰|<img src = "https://github.com/BostonGosari/Outline/assets/120548537/949a9ab4-e4fd-4e41-b592-c0f06d0095c4" width ="250">|
<br>

## 🗒️ Review Point
```
권한 설정을 하고 다음뷰로 넘어가는 형식이 `Navigation` 이 될지 단순히 뷰의 변경인 `transition` 으로 할지 논의해봐야 할 것 같습니다!
```
