### PR TITLE
fix #66 : 오류 수정

### DIFF
--- a/Outline/Outline/Source/View/GPSArtHome/BottomScrollView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/BottomScrollView.swift
@@ -11,8 +11,8 @@ import MapKit
 struct BottomScrollView: View {
     
     @ObservedObject var homeTabViewModel: HomeTabViewModel
-    @State private var showDetail = false
-    
+    @State private var selectedCourse: CourseWithDistance?
+
     var body: some View {
         VStack(alignment: .leading) {
             Text("이런 코스도 있어요.")
@@ -21,12 +21,12 @@ struct BottomScrollView: View {
             
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
-                    ForEach(homeTabViewModel.withoutRecommendedCourses, id: \.id) { currnetCourse in
+                    ForEach(homeTabViewModel.withoutRecommendedCourses, id: \.id) { currentCourse in
                         VStack {
                             Button {
-                                showDetail = true
+                                selectedCourse = currentCourse
                             } label: {
-                                AsyncImage(url: URL(string: currnetCourse.course.thumbnail))
+                                AsyncImage(url: URL(string: currentCourse.course.thumbnail))
                                     .fixedSize()
                                     .frame(width: 164, height: 236)
                                     .scaledToFit()
@@ -44,13 +44,13 @@ struct BottomScrollView: View {
                                     .overlay {
                                         VStack(alignment: .leading) {
                                             Spacer()
-                                            Text("\(currnetCourse.course.courseName)")
+                                            Text("\(currentCourse.course.courseName)")
                                                 .font(Font.system(size: 20).weight(.semibold))
                                                 .foregroundColor(.white)
                                             HStack(spacing: 0) {
                                                 Image(systemName: "mappin")
                                                     .foregroundColor(.gray600)
-                                                Text("\(currnetCourse.course.locationInfo.locality) \(currnetCourse.course.locationInfo.subLocality)")
+                                                Text("\(currentCourse.course.locationInfo.locality) \(currentCourse.course.locationInfo.subLocality)")
                                                     .foregroundColor(.gray600)
                                             }
                                             .font(.caption)
@@ -74,8 +74,8 @@ struct BottomScrollView: View {
                                     )
                             }
                         }
-                        .fullScreenCover(isPresented: $showDetail) {
-                            CourseDetailView(homeTabViewModel: homeTabViewModel, course: currnetCourse)
+                        .fullScreenCover(item: $selectedCourse) { course in
+                            CourseDetailView(homeTabViewModel: homeTabViewModel, course: course)
                         }
                     }
                 }


### PR DESCRIPTION
## 📌 Summary
- #66 

<br>

## ✨ Description
### 기존 문제
- showDetail 을 누르게 되면 모든 풀스크린 커버가 올라가게 되어 세개의 풀스크린 커버가 기존에 올라갔고, 가장 앞에있는 것이 보이게 된 것 같습니다.
```swift
@State private var showDetail = false

.fullScreenCover(isPresented: $showDetail) {
     CourseDetailView(homeTabViewModel: homeTabViewModel, course: currnetCourse)
}
```

### 문제해결
- `selectedCourse` 라는 변수를 만들어 버튼을 누를때 `selectedCourse` 가 띄워지게 했고, full screen cover 에서 `(item: $selectedCourse)` 를 전달받아 창을 띄웁니다.
```swift
@State private var selectedCourse: CourseWithDistance?

ForEach(homeTabViewModel.withoutRecommendedCourses, id: \.id) { currentCourse in
                        VStack {
                            Button {
                                selectedCourse = currentCourse
                            } label: {
                             .....
                            }
                        }
                        .fullScreenCover(item: $selectedCourse) { course in
                            CourseDetailView(homeTabViewModel: homeTabViewModel, course: course)
                        }
}
```


<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|선택한 경로 데이터 전달|<img src = "https://github.com/BostonGosari/Outline/assets/120548537/31708baf-8f34-450c-9c9e-1cfd5d33c655" width ="250">|

