### PR TITLE
data #69 : 러닝 타입 코어데이터 저장

### DIFF
--- a/Outline/Outline/Source/View/FreeRunning/FreeRunningHomeView.swift
+++ b/Outline/Outline/Source/View/FreeRunning/FreeRunningHomeView.swift
@@ -39,6 +39,9 @@ struct FreeRunningHomeView: View {
                            
                            Spacer()
                            SlideToUnlock(isUnlocked: $homeTabViewModel.start)
+                               .onChange(of: homeTabViewModel.start) { _, _ in
+                                   homeTabViewModel.runningType = .free
+                               }
                        }
                        .padding(EdgeInsets(top: 58, leading: 24, bottom: 24, trailing: 16))
                    }

--- a/Outline/Outline/Source/ViewModel/HomeTabViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/HomeTabViewModel.swift
@@ -26,6 +26,7 @@ class HomeTabViewModel: ObservableObject {
     @Published var startCourse: GPSArtCourse?
     @Published var start = false
     @Published var running = false
+    @Published var runningType: RunningType = .gpsArt
         
     let courseModel = CourseModel()
     let locationManager = CLLocationManager()


### PR DESCRIPTION
## 📌 Summary
- 러닝 타입 저장

<br>

## ✨ Description
- 러닝 타입을 저장하였습니다.
- 기본 값을 `gpsArt` 로 두고 `free` 시작일때 free 로 타입 변경하게만 하였습니다.

```swift
    @Published var runningType: RunningType = .gpsArt
```

## Review Point
```
- HomeTabViewModel 이 너무 방대해져 더이상 ViewModel 이 아닌 것 같습니다.... 리팩토링이 필요합니다.
- 초기값을 gpsArt 로 잡아도 될까요? 옵셔널로 하는게 나을까요?
```
