### PR TITLE
data #74 : 썸네일 변경 및 연결

### DIFF
--- a/Outline/Outline/Source/View/GPSArtHome/BottomScrollView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/BottomScrollView.swift
@@ -12,7 +12,7 @@ struct BottomScrollView: View {
     
     @ObservedObject var homeTabViewModel: HomeTabViewModel
     @State private var selectedCourse: CourseWithDistance?
-
+    
     var body: some View {
         VStack(alignment: .leading) {
             Text("이런 코스도 있어요.")
@@ -26,52 +26,56 @@ struct BottomScrollView: View {
                             Button {
                                 selectedCourse = currentCourse
                             } label: {
-                                AsyncImage(url: URL(string: currentCourse.course.thumbnail))
-                                    .fixedSize()
-                                    .frame(width: 164, height: 236)
-                                    .scaledToFit()
-                                    .overlay {
-                                        LinearGradient(
-                                            stops: [
-                                                Gradient.Stop(color: .black, location: 0.00),
-                                                Gradient.Stop(color: .black.opacity(0), location: 1.00)
-                                            ],
-                                            startPoint: UnitPoint(x: 0.5, y: 0.9),
-                                            endPoint: UnitPoint(x: 0.5, y: 0)
-                                        )
-                                        
-                                    }
-                                    .overlay {
-                                        VStack(alignment: .leading) {
-                                            Spacer()
-                                            Text("\(currentCourse.course.courseName)")
-                                                .font(Font.system(size: 20).weight(.semibold))
-                                                .foregroundColor(.white)
-                                            HStack(spacing: 0) {
-                                                Image(systemName: "mappin")
-                                                    .foregroundColor(.gray600)
-                                                Text("\(currentCourse.course.locationInfo.locality) \(currentCourse.course.locationInfo.subLocality)")
-                                                    .foregroundColor(.gray600)
-                                            }
-                                            .font(.caption)
-                                            .padding(.bottom, 16)
-                                        }
-                                        .frame(width: 164)
-                                        .offset(x: -15)
-                                    }
-                                    .roundedCorners(5, corners: [.topLeft])
-                                    .roundedCorners(30, corners: [.bottomLeft, .bottomRight, .topRight])
-                                    .foregroundColor(.clear)
-                                    .overlay(
-                                        CustomRoundedRectangle(
-                                            cornerRadiusTopLeft: 5,
-                                            cornerRadiusTopRight: 29,
-                                            cornerRadiusBottomLeft: 29,
-                                            cornerRadiusBottomRight: 29
-                                        )
-                                        .offset(x: 1, y: 1)
-                                        .frame(width: 166, height: 238)
+                                AsyncImage(url: URL(string: currentCourse.course.thumbnail)) { image in
+                                    image
+                                        .resizable()
+                                        .scaledToFill()
+                                } placeholder: {
+                                    Rectangle()
+                                }
+                                .frame(width: 164, height: 236)
+                                .overlay {
+                                    LinearGradient(
+                                        stops: [
+                                            Gradient.Stop(color: .black, location: 0.00),
+                                            Gradient.Stop(color: .black.opacity(0), location: 1.00)
+                                        ],
+                                        startPoint: UnitPoint(x: 0.5, y: 0.9),
+                                        endPoint: UnitPoint(x: 0.5, y: 0)
                                     )
+                                    
+                                }
+                                .overlay {
+                                    VStack(alignment: .leading) {
+                                        Spacer()
+                                        Text("\(currentCourse.course.courseName)")
+                                            .font(Font.system(size: 20).weight(.semibold))
+                                            .foregroundColor(.white)
+                                        HStack(spacing: 0) {
+                                            Image(systemName: "mappin")
+                                                .foregroundColor(.gray600)
+                                            Text("\(currentCourse.course.locationInfo.locality) \(currentCourse.course.locationInfo.subLocality)")
+                                                .foregroundColor(.gray600)
+                                        }
+                                        .font(.caption)
+                                        .padding(.bottom, 16)
+                                    }
+                                    .frame(width: 164)
+                                    .offset(x: -15)
+                                }
+                                .roundedCorners(5, corners: [.topLeft])
+                                .roundedCorners(30, corners: [.bottomLeft, .bottomRight, .topRight])
+                                .foregroundColor(.clear)
+                                .overlay(
+                                    CustomRoundedRectangle(
+                                        cornerRadiusTopLeft: 5,
+                                        cornerRadiusTopRight: 29,
+                                        cornerRadiusBottomLeft: 29,
+                                        cornerRadiusBottomRight: 29
+                                    )
+                                    .offset(x: 1, y: 1)
+                                    .frame(width: 166, height: 238)
+                                )
                             }
                         }
                         .fullScreenCover(item: $selectedCourse) { course in
@@ -231,11 +235,18 @@ struct CourseBannerView: View {
     }
     
     private var courseImage: some View {
-        Rectangle()
-            .foregroundColor(.gray800)
-            .roundedCorners(45, corners: [.bottomLeft])
-            .shadow(color: .white, radius: 0.5, y: 0.5)
-            .frame(height: 575)
+        AsyncImage(url: URL(string: course.course.thumbnail)) { image in
+            image
+                .resizable()
+                .scaledToFill()
+        } placeholder: {
+            Rectangle()
+                .scaledToFit()
+        }
+        .foregroundColor(.gray800)
+        .roundedCorners(45, corners: [.bottomLeft])
+        .shadow(color: .white, radius: 0.5, y: 0.5)
+        .frame(height: 575)
     }
     
     private var courseInformation: some View {
@@ -288,4 +299,8 @@ struct BottomScrollDetailView: View {
     var body: some View {
         Text("1")
     }
+}
+
+#Preview {
+    HomeTabView()
 }

--- a/Outline/Outline/Source/View/GPSArtHome/CardDetailView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/CardDetailView.swift
@@ -74,12 +74,19 @@ struct CardDetailView: View {
     // MARK: - View Components
     
     private var courseImage: some View {
-        Rectangle()
-            .foregroundColor(.gray800)
-            .roundedCorners(45, corners: [.bottomLeft])
-            .shadow(color: .white, radius: 0.5, y: 0.5)
-            .matchedGeometryEffect(id: "courseImage\(currentIndex)", in: namespace)
-            .frame(height: cardHeight)
+        AsyncImage(url: URL(string: homeTabViewModel.recommendedCoures[currentIndex].course.thumbnail)) { image in
+            image
+                .resizable()
+                .scaledToFill()
+        } placeholder: {
+            Rectangle()
+                .scaledToFit()
+        }
+        .foregroundColor(.gray800)
+        .roundedCorners(45, corners: [.bottomLeft])
+        .shadow(color: .white, radius: 0.5, y: 0.5)
+        .matchedGeometryEffect(id: "courseImage\(currentIndex)", in: namespace)
+        .frame(height: cardHeight)
     }
     
     private var courseInformation: some View {

--- a/Outline/Outline/Source/View/GPSArtHome/CardView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/CardView.swift
@@ -39,16 +39,36 @@ struct CardView: View {
     }
     
     // MARK: - View Components
-    
     private var courseImage: some View {
-        Rectangle()
-            .frame(width: cardWidth, height: cardHeight)
-            .foregroundColor(.gray900Color)
-            .roundedCorners(10, corners: [.topLeft])
-            .roundedCorners(70, corners: [.topRight])
-            .roundedCorners(45, corners: [.bottomLeft, .bottomRight])
-            .shadow(color: .white, radius: 0.5, y: -0.5)
-            .matchedGeometryEffect(id: "courseImage\(pageIndex)", in: namespace)
+        if pageIndex < homeTabViewModel.recommendedCoures.count {
+            return AnyView(
+                AsyncImage(url: URL(string: homeTabViewModel.recommendedCoures[pageIndex].course.thumbnail)) { image in
+                    image
+                        .resizable()
+                        .scaledToFill()
+                } placeholder: {
+                    Rectangle()
+                        .foregroundColor(.gray900Color)
+                }
+                .frame(width: cardWidth, height: cardHeight)
+                .roundedCorners(10, corners: [.topLeft])
+                .roundedCorners(70, corners: [.topRight])
+                .roundedCorners(45, corners: [.bottomLeft, .bottomRight])
+                .shadow(color: .white, radius: 0.5, y: -0.5)
+                .matchedGeometryEffect(id: "courseImage\(pageIndex)", in: namespace)
+            )
+        } else {
+            return AnyView(
+                Rectangle()
+                    .frame(width: cardWidth, height: cardHeight)
+                    .foregroundColor(.gray900Color)
+                    .roundedCorners(10, corners: [.topLeft])
+                    .roundedCorners(70, corners: [.topRight])
+                    .roundedCorners(45, corners: [.bottomLeft, .bottomRight])
+                    .shadow(color: .white, radius: 0.5, y: -0.5)
+                    .matchedGeometryEffect(id: "courseImage\(pageIndex)", in: namespace)
+            )
+        }
     }
     
     private var courseInformation: some View {

--- a/Outline/Outline/Source/View/GPSArtHome/GPSArtHomeView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/GPSArtHomeView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct GPSArtHomeView: View {
     
     @ObservedObject var homeTabViewModel: HomeTabViewModel
-
+    
     @State private var scrollOffset: CGFloat = 0
     @State var currentIndex: Int = 0
     
@@ -84,4 +84,8 @@ struct GPSArtHomeView: View {
             BackgroundBlur()
         )
     }
+}
+
+#Preview {
+    HomeTabView()
 }


### PR DESCRIPTION
## 📌 Summary
- #74 
- 썸네일 변경 및 연결

<br>

## ✨ Description
### 파이어 베이스 썸네일 변경
<img width="1389" alt="스크린샷 2023-10-23 19 48 24" src="https://github.com/BostonGosari/Outline/assets/120548537/eacbdef0-7a2d-4605-ad12-7ab016af8123">

### Rectangle 에 해당 썸네일 연결
- `AsyncImage` 를 활용하였습니다.
```swift
                AsyncImage(url: URL(string: homeTabViewModel.recommendedCoures[pageIndex].course.thumbnail)) { image in
                    image
                        .resizable()
                        .scaledToFill()
                } placeholder: {
                    Rectangle()
                        .foregroundColor(.gray900Color)
                }
```
- 큰 문제는 용량 사용이 너무 많습니다...

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|Firestore 이미지 불러오기|<img src = "https://github.com/BostonGosari/Outline/assets/120548537/1d129ae0-377c-4d28-8cf2-bb201e7e7f16" width ="250">|

<br>

## 🗒️ Review Point
```
🚨 수정이 꼭 필요합니다 : 이미지를 불러올때마다 url 을 사용하여 데이터 사용량이 많습니다... 이부분 어떻게 최적화 해야할까요...?
```
