### PR TITLE
design #76 : 러닝 완료 sheet 구현

### DIFF
--- a/Outline/Outline/Source/View/Running/RunningMapView.swift
+++ b/Outline/Outline/Source/View/Running/RunningMapView.swift
@@ -20,6 +20,7 @@ struct RunningMapView: View {
     @Binding var selection: Int
     
     @State var navigateToFinishRunningView = false
+    @State var showCustomSheet = false
     
     var body: some View {
         ZStack {
@@ -40,6 +41,9 @@ struct RunningMapView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.bottom, 80)
             }
+        }
+        .sheet(isPresented: $showCustomSheet) {
+            customSheet
         }
         .overlay {
             if viewModel.isShowPopup {
@@ -117,9 +121,10 @@ extension RunningMapView {
                                 .onEnded { _ in
                                     print("Long press ended")
                                     HapticManager.impact(style: .medium)
+                                    locationManager.stopUpdateLocation()
                                     runningViewModel.stopRunning()
                                     digitalTimerViewModel.counter = 0
-                                    navigateToFinishRunningView = true
+                                    showCustomSheet = true
                                 }
                         )
                         .highPriorityGesture(
@@ -154,6 +159,31 @@ extension RunningMapView {
                 EmptyView()
             )
         }
+    }
+    
+    private var customSheet: some View {
+        VStack(spacing: 0) {
+            Text("오늘은, 여기까지")
+                .font(.title2)
+                .padding(.top, 56)
+                .padding(.bottom, 8)
+            Text("즐거운 러닝이었나요? 다음에 또 만나요! ")
+                .font(.subBody)
+                .padding(.bottom, 24)
+            
+            Image("Finish10")
+                .resizable()
+                .frame(width: 120, height: 120)
+                .padding(.bottom, 45)
+            
+            CompleteButton(text: "결과 페이지로") {
+                showCustomSheet = false
+                navigateToFinishRunningView = true
+            }
+        }
+        .presentationDetents([.height(420)])
+        .presentationCornerRadius(35)
+        .interactiveDismissDisabled()
     }
 }
 


### PR DESCRIPTION
## 📌 Summary
- #76 
- 러닝 완료시 나타나는 sheet 구현
<br>

## ✨ Description
- 중지 버튼을 길게 눌러 러닝 완료가 되면 sheet를 나타낸다.
- sheet에서 버튼을 누르면 다음 view로 이동한다.
```swift
private var customSheet: some View {
      VStack(spacing: 0) {
          Text("오늘은, 여기까지")
              .font(.title2)
              .padding(.top, 56)
              .padding(.bottom, 8)
          Text("즐거운 러닝이었나요? 다음에 또 만나요! ")
              .font(.subBody)
              .padding(.bottom, 24)
          
          Image("Finish10")
              .resizable()
              .frame(width: 120, height: 120)
              .padding(.bottom, 45)
          
          CompleteButton(text: "결과 페이지로") {
              showCustomSheet = false
              navigateToFinishRunningView = true
          }
      }
      .presentationDetents([.height(420)])
      .presentationCornerRadius(35)
      .interactiveDismissDisabled()
  }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|sheet|<img src = "https://github.com/BostonGosari/Outline/assets/55949986/a063f3f2-4944-4be9-b8ec-d62a0779a6fb" width ="250">|
