### PR TITLE
feature #73 이미지 렌더링

### DIFF
--- a/Outline/Outline/Source/DesignSystem/Extension/ViewExtension.swift
+++ b/Outline/Outline/Source/DesignSystem/Extension/ViewExtension.swift
@@ -37,4 +37,21 @@ extension View {
                 action(value)
             }
     }
+    
+    func asImage(size: CGSize) -> UIImage {
+        let controller = UIHostingController(rootView: self)
+        controller.view.bounds = CGRect(origin: .zero, size: size)
+        let image = controller.view.asImage(size: size)
+        return image
+    }
+}
+
+extension UIView {
+    func asImage(size: CGSize) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: size, format: format).image { context in
+            self.drawHierarchy(in: self.layer.bounds, afterScreenUpdates: true)
+        }
+    }
 }

--- a/Outline/Outline/Source/Manager/PathGenerateManager.swift
+++ b/Outline/Outline/Source/Manager/PathGenerateManager.swift
@@ -32,6 +32,9 @@ final class PathGenerateManager {
     func caculateLines(width: Double, height: Double, coordinates: [CLLocationCoordinate2D]) -> some Shape {
         let canvasData = calculateCanvaData(coordinates: coordinates, width: width, height: height)
         var path = Path()
+        if coordinates.isEmpty {
+            return path
+        }
         
         let position = calculateRelativePoint(coordinate: coordinates[0], canvasData: canvasData)
         path.move(to: CGPoint(x: position[0], y: -position[1]))

--- a/Outline/Outline/Source/Manager/PathGenerateManager.swift
+++ b/Outline/Outline/Source/Manager/PathGenerateManager.swift
@@ -16,6 +16,15 @@ struct CanvasData {
     var zeroY: Double
 }
 
+struct CanvasDataForShare {
+    var width: Int
+    var height: Int
+    var widthScale: Double
+    var heightScale: Double
+    var zeroX: Double
+    var zeroY: Double
+}
+
 final class PathGenerateManager {
     static let shared = PathGenerateManager()
     private init() {}

--- a/Outline/Outline/Source/OutlineApp.swift
+++ b/Outline/Outline/Source/OutlineApp.swift
@@ -21,13 +21,14 @@ struct OutlineApp: App {
         WindowGroup {
             ShareMainView(homeTabViewModel: HomeTabViewModel(), runningData: ShareModel(courseName: "댕댕런", runningDate: "2022년 10월", runningRegion: "세빛섬", distance: "10km", cal: "400cal", pace: "5분", bpm: "150bpm", time: "30분", userLocations: [
                 CLLocationCoordinate2D(latitude: 37.5118066, longitude: 126.9943851),
-                CLLocationCoordinate2D(latitude: 37.5118166, longitude: 126.9953951),
-                CLLocationCoordinate2D(latitude: 37.5147866, longitude: 126.9953751),
-                CLLocationCoordinate2D(latitude: 37.5137566, longitude: 126.9943751),
                 CLLocationCoordinate2D(latitude: 37.5107566, longitude: 126.9943751),
                 CLLocationCoordinate2D(latitude: 37.5027566, longitude: 126.9947751),
                 CLLocationCoordinate2D(latitude: 37.5057566, longitude: 126.9941451),
                 CLLocationCoordinate2D(latitude: 37.5017566, longitude: 126.9946751),
+                CLLocationCoordinate2D(latitude: 37.5037566, longitude: 126.9946751),
+                CLLocationCoordinate2D(latitude: 37.5057566, longitude: 126.99463751),
+                CLLocationCoordinate2D(latitude: 37.5067566, longitude: 126.9942751),
+                
             ]))
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
 

--- a/Outline/Outline/Source/OutlineApp.swift
+++ b/Outline/Outline/Source/OutlineApp.swift
@@ -20,12 +20,14 @@ struct OutlineApp: App {
     var body: some Scene {
         WindowGroup {
             ShareMainView(homeTabViewModel: HomeTabViewModel(), runningData: ShareModel(courseName: "댕댕런", runningDate: "2022년 10월", runningRegion: "세빛섬", distance: "10km", cal: "400cal", pace: "5분", bpm: "150bpm", time: "30분", userLocations: [
-                CLLocationCoordinate2D(latitude: 37.5107866, longitude: 126.9943651),
-                CLLocationCoordinate2D(latitude: 37.5107966, longitude: 126.9933751),
                 CLLocationCoordinate2D(latitude: 37.5118066, longitude: 126.9943851),
                 CLLocationCoordinate2D(latitude: 37.5118166, longitude: 126.9953951),
                 CLLocationCoordinate2D(latitude: 37.5147866, longitude: 126.9953751),
-                CLLocationCoordinate2D(latitude: 37.5137566, longitude: 126.9943751)
+                CLLocationCoordinate2D(latitude: 37.5137566, longitude: 126.9943751),
+                CLLocationCoordinate2D(latitude: 37.5107566, longitude: 126.9943751),
+                CLLocationCoordinate2D(latitude: 37.5027566, longitude: 126.9947751),
+                CLLocationCoordinate2D(latitude: 37.5057566, longitude: 126.9941451),
+                CLLocationCoordinate2D(latitude: 37.5017566, longitude: 126.9946751),
             ]))
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
 

--- a/Outline/Outline/Source/OutlineApp.swift
+++ b/Outline/Outline/Source/OutlineApp.swift
@@ -6,6 +6,7 @@
 //
 
 import Firebase
+import CoreLocation
 import SwiftUI
 
 @main
@@ -18,7 +19,14 @@ struct OutlineApp: App {
   
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ShareMainView(homeTabViewModel: HomeTabViewModel(), runningData: ShareModel(courseName: "댕댕런", runningDate: "2022년 10월", runningRegion: "세빛섬", distance: "10km", cal: "400cal", pace: "5분", bpm: "150bpm", time: "30분", userLocations: [
+                CLLocationCoordinate2D(latitude: 37.5107866, longitude: 126.9943651),
+                CLLocationCoordinate2D(latitude: 37.5107966, longitude: 126.9933751),
+                CLLocationCoordinate2D(latitude: 37.5118066, longitude: 126.9943851),
+                CLLocationCoordinate2D(latitude: 37.5118166, longitude: 126.9953951),
+                CLLocationCoordinate2D(latitude: 37.5147866, longitude: 126.9953751),
+                CLLocationCoordinate2D(latitude: 37.5137566, longitude: 126.9943751)
+            ]))
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
 
         }

--- a/Outline/Outline/Source/OutlineApp.swift
+++ b/Outline/Outline/Source/OutlineApp.swift
@@ -19,17 +19,7 @@ struct OutlineApp: App {
   
     var body: some Scene {
         WindowGroup {
-            ShareMainView(homeTabViewModel: HomeTabViewModel(), runningData: ShareModel(courseName: "댕댕런", runningDate: "2022년 10월", runningRegion: "세빛섬", distance: "10km", cal: "400cal", pace: "5분", bpm: "150bpm", time: "30분", userLocations: [
-                CLLocationCoordinate2D(latitude: 37.5118066, longitude: 126.9943851),
-                CLLocationCoordinate2D(latitude: 37.5107566, longitude: 126.9943751),
-                CLLocationCoordinate2D(latitude: 37.5027566, longitude: 126.9947751),
-                CLLocationCoordinate2D(latitude: 37.5057566, longitude: 126.9941451),
-                CLLocationCoordinate2D(latitude: 37.5017566, longitude: 126.9946751),
-                CLLocationCoordinate2D(latitude: 37.5037566, longitude: 126.9946751),
-                CLLocationCoordinate2D(latitude: 37.5057566, longitude: 126.99463751),
-                CLLocationCoordinate2D(latitude: 37.5067566, longitude: 126.9942751),
-                
-            ]))
+            ContentView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
 
         }

--- a/Outline/Outline/Source/View/Share/CustomShareView.swift
+++ b/Outline/Outline/Source/View/Share/CustomShareView.swift
@@ -21,33 +21,38 @@ struct CustomShareView: View {
     
     @State private var renderedImage: UIImage?
     @State private var mapView = MKMapView()
+    @State private var imageWidth: CGFloat = 0
+    
+    private let pathManager = PathGenerateManager.shared
+    
     
     var body: some View {
         ZStack {
             Color.gray900Color
                 .ignoresSafeArea()
-            
-            VStack(spacing: 0) {
-                customImageView
-                    .padding(EdgeInsets(top: 20, leading: 49, bottom: 16, trailing: 49))
-                if let renderedImage = renderedImage {
-                    Image(uiImage: renderedImage)
+            ScrollView{
+                VStack(spacing: 0) {
+                    customImageView
+                        .padding(EdgeInsets(top: 20, leading: 49, bottom: 16, trailing: 49))
+                    if let renderedImage = renderedImage {
+                        Image(uiImage: renderedImage)
+                    }
+                    Button {
+                        renderLayerImage()
+                    } label: {
+                        Text("render Image")
+                    }
+                    pageIndicator
+                    tagView
                 }
-                Button {
-                    renderLayerImage()
-                } label: {
-                    Text("render Image")
-                }
-                pageIndicator
-                tagView
             }
         }
     }
 }
 
 extension CustomShareView {
-    private func renderLayerImage(){
-        
+    private func renderLayerImage() {
+        renderMapViewAsImage(width: Int(imageWidth))
     }
 }
 
@@ -59,6 +64,12 @@ extension CustomShareView {
                     LinearGradient(colors: [.black.opacity(0), .black], startPoint: .center, endPoint: .bottom)
                 }
             runningInfo
+            GeometryReader { proxy in
+                HStack {}
+                    .onAppear {
+                        imageWidth = proxy.size.width - 98
+                }
+            }
         }
         .aspectRatio(1080.0/1920.0, contentMode: .fit)
         
@@ -158,4 +169,153 @@ struct TagButton: View {
     }
 }
 
+extension CustomShareView {
+    func renderMapViewAsImage(width: Int) {
+        let options: MKMapSnapshotter.Options = .init()
+        options.region = mapView.region
+        options.size = CGSize(width: width, height: Int(width * 1920 / 1080) )
+        options.mapType = .standard
+        options.showsBuildings = true
+        
+        let snapshotter = MKMapSnapshotter(
+            options: options
+        )
+        snapshotter.start { snapshot, error in
+           if let snapshot = snapshot {
+               let renderedMapImage = snapshot.image
+               renderedImage = overlayMapInfo(renderdImage: renderedMapImage).asImage(size: CGSize(width: width, height: Int(width * 1920 / 1080 )))
+           } else if let error = error {
+              print(error)
+           }
+        }
+    }
+    func overlayMapInfo(renderdImage: UIImage) -> some View {
+        ZStack {
+            Image(uiImage: renderdImage)
+            runningInfo
+            pathManager.caculateLinesInRect(width: imageWidth, height: Double(Int(imageWidth * 1920 / 1080)), coordinates: viewModel.runningData.userLocations, region: mapView.region)
+                .stroke(lineWidth: 6)
+        }
+        .aspectRatio(1080.0/1920.0, contentMode: .fit)
+    }
+}
 
+
+extension PathGenerateManager {
+    func caculateLinesInRect(
+        width: Double,
+        height: Double,
+        coordinates: [CLLocationCoordinate2D],
+        region: MKCoordinateRegion
+    ) -> some Shape {
+        let canvasData = calculateCanvaDataInRect(width: width, height: height, region: region)
+        print(canvasData)
+        var path = Path()
+        
+        let startPosition = calculateRelativePoint(coordinate: coordinates[0], canvasData: canvasData)
+        path.move(to: CGPoint(x: startPosition[0], y: -startPosition[1]))
+
+        for coordinate in coordinates {
+            let position = calculateRelativePoint(coordinate: coordinate, canvasData: canvasData)
+            path.addLine(to: CGPoint(x: position[0], y: -position[1]))
+        }
+        
+        return path
+    }
+    
+    private func calculateCanvaDataInRect(width: Double, height: Double, region: MKCoordinateRegion) -> CanvasData {
+        let minLon = region.center.longitude - region.span.longitudeDelta / 2
+        let maxLon = region.center.longitude + region.span.longitudeDelta / 2
+        let minLat = region.center.latitude - region.span.latitudeDelta / 2
+        let maxLat = region.center.latitude + region.span.latitudeDelta / 2
+        
+        let calculatedHeight = region.span.latitudeDelta * 1000000
+        let calculatedWidth = region.span.longitudeDelta * 1000000
+        
+        let relativeScale: Double = height / calculatedHeight
+        
+        let fittedWidth = calculatedWidth * relativeScale
+        let fittedHeight = calculatedHeight * relativeScale
+        return CanvasData(
+            width: Int(fittedWidth),
+            height: Int(fittedHeight),
+            scale: relativeScale,
+            zeroX: minLon,
+            zeroY: maxLat
+            )
+    }
+    
+    private func calculateCanvaData(coordinates: [CLLocationCoordinate2D], width: Double, height: Double) -> CanvasData {
+        var minLat: Double = 90
+        var maxLat: Double = -90
+        var minLon: Double = 180
+        var maxLon: Double = -180
+        for coordinate in coordinates {
+            if coordinate.latitude < minLat {
+                minLat = coordinate.latitude
+            }
+            if coordinate.latitude > maxLat {
+                maxLat = coordinate.latitude
+            }
+            if coordinate.longitude < minLon {
+                minLon = coordinate.longitude
+            }
+            if coordinate.longitude > maxLon {
+                maxLon = coordinate.longitude
+            }
+        }
+        let calculatedHeight = (maxLat - minLat) * 1000000
+        let calculatedWidth = (maxLon - minLon) * 1000000
+        
+        var relativeScale: Double = 0
+        
+        if calculatedWidth > calculatedHeight {
+            relativeScale = width / calculatedWidth
+        } else {
+            relativeScale = height / calculatedHeight
+        }
+        let fittedWidth = calculatedWidth * relativeScale
+        let fittedHeight = calculatedHeight * relativeScale
+        
+        return CanvasData(
+            width: Int(fittedWidth),
+            height: Int(fittedHeight),
+            scale: relativeScale,
+            zeroX: minLon,
+            zeroY: maxLat
+            )
+    }
+    
+    func calculateDeltaAndCenter(coordinates: [CLLocationCoordinate2D]) -> MKCoordinateRegion {
+        var minLat: Double = 90
+        var maxLat: Double = -90
+        var minLon: Double = 180
+        var maxLon: Double = -180
+        for coordinate in coordinates {
+            if coordinate.latitude < minLat {
+                minLat = coordinate.latitude
+            }
+            if coordinate.latitude > maxLat {
+                maxLat = coordinate.latitude
+            }
+            if coordinate.longitude < minLon {
+                minLon = coordinate.longitude
+            }
+            if coordinate.longitude > maxLon {
+                maxLon = coordinate.longitude
+            }
+        }
+        let latitudeDelta = maxLat - minLat
+        let longitudeDelta = maxLon - minLon
+        let centerLatitude = (maxLat + minLat) / 2
+        let centerLongitude = (maxLon + minLon) / 2
+        
+        return MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: centerLatitude, longitude: centerLongitude), span: MKCoordinateSpan(latitudeDelta: latitudeDelta, longitudeDelta: longitudeDelta))
+    }
+    
+    private func calculateRelativePoint(coordinate: CLLocationCoordinate2D, canvasData: CanvasData) -> [Int] {
+        let posX = Int((coordinate.longitude - canvasData.zeroX) * canvasData.scale * 1000000)
+        let posY = Int((coordinate.latitude - canvasData.zeroY) * canvasData.scale * 1000000)
+        return [posX, posY]
+    }
+}

--- a/Outline/Outline/Source/View/Share/CustomShareView.swift
+++ b/Outline/Outline/Source/View/Share/CustomShareView.swift
@@ -31,15 +31,20 @@ struct CustomShareView: View {
         ZStack {
             Color.gray900Color
                 .ignoresSafeArea()
-            ScrollView {
-                VStack(spacing: 0) {
-                    customImageView
-                        .padding(EdgeInsets(top: 20, leading: 49, bottom: 16, trailing: 49))
-                    pageIndicator
-                    tagView
-                }
+            
+            VStack(spacing: 0) {
+                customImageView
+                    .padding(EdgeInsets(top: 20, leading: 49, bottom: 16, trailing: 49))
+                pageIndicator
+                tagView
             }
+            
         }
+        .onChange(of: viewModel.currentPage, {
+            if viewModel.currentPage == 0 {
+                renderLayerImage()
+            }
+        })
         .onAppear {
             renderLayerImage()
         }

--- a/Outline/Outline/Source/View/Share/CustomShareView.swift
+++ b/Outline/Outline/Source/View/Share/CustomShareView.swift
@@ -6,6 +6,7 @@
 //
 
 import CoreLocation
+import MapKit
 import SwiftUI
 
 struct CustomShareView: View {
@@ -18,6 +19,9 @@ struct CustomShareView: View {
     @State private var isShowPace = true
     @State private var isShowDistance = true
     
+    @State private var renderedImage: UIImage?
+    @State private var mapView = MKMapView()
+    
     var body: some View {
         ZStack {
             Color.gray900Color
@@ -26,7 +30,14 @@ struct CustomShareView: View {
             VStack(spacing: 0) {
                 customImageView
                     .padding(EdgeInsets(top: 20, leading: 49, bottom: 16, trailing: 49))
-        
+                if let renderedImage = renderedImage {
+                    Image(uiImage: renderedImage)
+                }
+                Button {
+                    renderLayerImage()
+                } label: {
+                    Text("render Image")
+                }
                 pageIndicator
                 tagView
             }
@@ -35,9 +46,15 @@ struct CustomShareView: View {
 }
 
 extension CustomShareView {
+    private func renderLayerImage(){
+        
+    }
+}
+
+extension CustomShareView {
     private var customImageView: some View {
         ZStack {
-            ShareMap(userLocations: viewModel.runningData.userLocations)
+            ShareMap(mapView: $mapView, userLocations: viewModel.runningData.userLocations)
                 .overlay {
                     LinearGradient(colors: [.black.opacity(0), .black], startPoint: .center, endPoint: .bottom)
                 }
@@ -140,3 +157,5 @@ struct TagButton: View {
         }
     }
 }
+
+

--- a/Outline/Outline/Source/View/Share/CustomShareView.swift
+++ b/Outline/Outline/Source/View/Share/CustomShareView.swift
@@ -20,7 +20,7 @@ struct CustomShareView: View {
     @State private var isShowDistance = true
     
     // handle Image
-    @State private var renderedImage: UIImage?
+    @Binding var renderedImage: UIImage?
     @State private var mapView = MKMapView()
     @State private var imageWidth: CGFloat = 0
     @State private var imageHeight: CGFloat = 0
@@ -39,6 +39,9 @@ struct CustomShareView: View {
                     tagView
                 }
             }
+        }
+        .onAppear {
+            renderLayerImage()
         }
     }
 }

--- a/Outline/Outline/Source/View/Share/CustomShareView.swift
+++ b/Outline/Outline/Source/View/Share/CustomShareView.swift
@@ -35,14 +35,6 @@ struct CustomShareView: View {
                 VStack(spacing: 0) {
                     customImageView
                         .padding(EdgeInsets(top: 20, leading: 49, bottom: 16, trailing: 49))
-                    if let renderedImage = renderedImage {
-                        Image(uiImage: renderedImage)
-                    }
-                    Button {
-                        renderLayerImage()
-                    } label: {
-                        Text("render Image")
-                    }
                     pageIndicator
                     tagView
                 }
@@ -232,7 +224,7 @@ extension PathGenerateManager {
         return path
     }
     
-    private func calculateCanvaDataInRect(width: Double, height: Double, region: MKCoordinateRegion) -> CanvasData {
+    private func calculateCanvaDataInRect(width: Double, height: Double, region: MKCoordinateRegion) -> CanvasDataForShare {
         let minLon = region.center.longitude - region.span.longitudeDelta / 2
 //        let maxLon = region.center.longitude + region.span.longitudeDelta / 2
 //        let minLat = region.center.latitude - region.span.latitudeDelta / 2
@@ -241,14 +233,16 @@ extension PathGenerateManager {
         let calculatedHeight = region.span.latitudeDelta * 1000000
         let calculatedWidth = region.span.longitudeDelta * 1000000
         
-        let relativeScale: Double = height / calculatedHeight
+        let relativeWidthScale: Double = width / calculatedWidth
+        let relativeHeightScale: Double = height / calculatedHeight
         
-        let fittedWidth = calculatedWidth * relativeScale
-        let fittedHeight = calculatedHeight * relativeScale
-        return CanvasData(
+        let fittedWidth = calculatedWidth * relativeWidthScale
+        let fittedHeight = calculatedHeight * relativeHeightScale
+        return CanvasDataForShare(
             width: Int(fittedWidth),
             height: Int(fittedHeight),
-            scale: relativeScale,
+            widthScale: relativeWidthScale,
+            heightScale: relativeHeightScale,
             zeroX: minLon,
             zeroY: maxLat
             )
@@ -322,9 +316,9 @@ extension PathGenerateManager {
         return MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: centerLatitude, longitude: centerLongitude), span: MKCoordinateSpan(latitudeDelta: latitudeDelta, longitudeDelta: longitudeDelta))
     }
     
-    private func calculateRelativePoint(coordinate: CLLocationCoordinate2D, canvasData: CanvasData) -> [Int] {
-        let posX = Int((coordinate.longitude - canvasData.zeroX) * canvasData.scale * 1000000)
-        let posY = Int((coordinate.latitude - canvasData.zeroY) * canvasData.scale * 1000000)
+    private func calculateRelativePoint(coordinate: CLLocationCoordinate2D, canvasData: CanvasDataForShare) -> [Int] {
+        let posX = Int((coordinate.longitude - canvasData.zeroX) * canvasData.widthScale * 1000000)
+        let posY = Int((coordinate.latitude - canvasData.zeroY) * canvasData.heightScale * 1000000)
         return [posX, posY]
     }
 }

--- a/Outline/Outline/Source/View/Share/ImageShareView.swift
+++ b/Outline/Outline/Source/View/Share/ImageShareView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ImageShareView: View {
     
     @ObservedObject var viewModel: ShareViewModel
+    @Binding var shareImage: UIImage?
     
     @State private var selectPhotoMode = false
     @State private var showSheet = false
@@ -39,25 +40,13 @@ struct ImageShareView: View {
                 .ignoresSafeArea()
             
             VStack(spacing: 0) {
-                GeometryReader { geo in
-                    ZStack {
-                        if selectPhotoMode {
-                            selectPhotoView
-                        } else {
-                            blackImageView
-                        }
-                    }
-                    .aspectRatio(1080/1920, contentMode: .fit)
+                mainImageView
                     .padding(EdgeInsets(top: 20, leading: 49, bottom: 16, trailing: 49))
-                    .onAppear {
-                        self.size = CGSize(width: geo.size.width-98, height: geo.size.height-36)
-                    }
                     .mask {
                         Rectangle()
                             .frame(maxWidth: .infinity, alignment: .center)
                             .aspectRatio(1080.0/1920.0, contentMode: .fit)
                     }
-                }
                 pageIndicator
                 selectModeView
             }
@@ -71,10 +60,46 @@ struct ImageShareView: View {
             lastAngle = .degrees(0)
         }
         .modifier(SheetModifier(viewModel: viewModel, showSheet: $showSheet, image: $image))
+        .onChange(of: viewModel.currentPage, {
+            if viewModel.currentPage == 1 {
+                renderImage()
+            }
+        })
+        .onChange(of: selectPhotoMode, {
+            renderImage()
+        })
+        .onChange(of: image) { 
+            renderImage()
+        }
     }
 }
 
 extension ImageShareView {
+    
+    private func renderImage() {
+        shareImage = mainImageView.asImage(size: size)
+    }
+    
+    private var mainImageView: some View {
+        Group {
+            ZStack {
+                if selectPhotoMode {
+                    selectPhotoView
+                } else {
+                    blackImageView
+                }
+                GeometryReader { proxy in
+                    HStack {}
+                        .onAppear {
+                            size = CGSize(width: proxy.size.width, height: proxy.size.height)
+                            print(proxy.size)
+                    }
+                }
+            }
+            .aspectRatio(1080/1920, contentMode: .fit)
+        }
+    }
+    
     private var selectPhotoView: AnyView {
         if let img = image {
             AnyView(

--- a/Outline/Outline/Source/View/Share/ShareMainView.swift
+++ b/Outline/Outline/Source/View/Share/ShareMainView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct ShareMainView: View {
     @ObservedObject var homeTabViewModel: HomeTabViewModel
     @StateObject private var viewModel = ShareViewModel()
-    @State private var renderedImage: UIImage?
     
     let runningData: ShareModel
     
@@ -22,7 +21,7 @@ struct ShareMainView: View {
                     .ignoresSafeArea()
                 
                 TabView(selection: $viewModel.currentPage) {
-                    CustomShareView(viewModel: viewModel, renderedImage: $renderedImage)
+                    CustomShareView(viewModel: viewModel, renderedImage: $viewModel.shareImage)
                         .tag(0)
                     ImageShareView(viewModel: viewModel)
                         .tag(1)
@@ -32,10 +31,7 @@ struct ShareMainView: View {
                 HStack(spacing: 0) {
                     Button {
                         viewModel.tapSaveButton = true
-                        if let renderedImage = renderedImage {
-                            // share image
-                        }
-//                        viewModel.saveImage()
+                        viewModel.saveImage()
                     }  label: {
                         Image(systemName: "square.and.arrow.down")
                             .foregroundStyle(Color.black)

--- a/Outline/Outline/Source/View/Share/ShareMainView.swift
+++ b/Outline/Outline/Source/View/Share/ShareMainView.swift
@@ -23,7 +23,7 @@ struct ShareMainView: View {
                 TabView(selection: $viewModel.currentPage) {
                     CustomShareView(viewModel: viewModel, renderedImage: $viewModel.shareImage)
                         .tag(0)
-                    ImageShareView(viewModel: viewModel)
+                    ImageShareView(viewModel: viewModel, shareImage: $viewModel.shareImage)
                         .tag(1)
                 }
                 .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))

--- a/Outline/Outline/Source/View/Share/ShareMainView.swift
+++ b/Outline/Outline/Source/View/Share/ShareMainView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct ShareMainView: View {
     @ObservedObject var homeTabViewModel: HomeTabViewModel
     @StateObject private var viewModel = ShareViewModel()
+    @State private var renderedImage: UIImage?
+    
     let runningData: ShareModel
     
     var body: some View {
@@ -20,7 +22,7 @@ struct ShareMainView: View {
                     .ignoresSafeArea()
                 
                 TabView(selection: $viewModel.currentPage) {
-                    CustomShareView(viewModel: viewModel)
+                    CustomShareView(viewModel: viewModel, renderedImage: $renderedImage)
                         .tag(0)
                     ImageShareView(viewModel: viewModel)
                         .tag(1)
@@ -30,7 +32,10 @@ struct ShareMainView: View {
                 HStack(spacing: 0) {
                     Button {
                         viewModel.tapSaveButton = true
-                        viewModel.saveImage()
+                        if let renderedImage = renderedImage {
+                            // share image
+                        }
+//                        viewModel.saveImage()
                     }  label: {
                         Image(systemName: "square.and.arrow.down")
                             .foregroundStyle(Color.black)

--- a/Outline/Outline/Source/View/Share/ShareMap.swift
+++ b/Outline/Outline/Source/View/Share/ShareMap.swift
@@ -10,10 +10,10 @@ import SwiftUI
 
 struct ShareMap: UIViewRepresentable {
     
+    @Binding var mapView: MKMapView
     let userLocations: [CLLocationCoordinate2D]
     
     func makeUIView(context: Context) -> MKMapView {
-        let mapView = MKMapView()
         mapView.delegate = context.coordinator
         mapView.isUserInteractionEnabled = false
         

--- a/Outline/Outline/Source/ViewModel/ShareViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/ShareViewModel.swift
@@ -67,7 +67,6 @@ class ShareViewModel: ObservableObject {
     }
     
     func shareToInstagram() -> Bool {
-        shareImage = UIImage(named: "ShareVinyl")
         guard let url = URL(string: "instagram-stories://share?source_application=helia"),
               let image = shareImage,
               let imageData = image.pngData() else { return false }
@@ -89,6 +88,7 @@ class ShareViewModel: ObservableObject {
     
     func saveImage() {
         if let image = shareImage {
+            print(currentPage)
             let imageSaver = ImageSaver()
             imageSaver.writeToPhotoAlbum(image: image)
             
@@ -106,4 +106,3 @@ class ImageSaver: NSObject {
         print("Save finished!")
     }
 }
-


### PR DESCRIPTION
## 📌 Summary
#73 
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->

<br>

## ✨ Description

## CustomShareView의 이미지 렌더링 구현

> CustomShareView에서 Map이 캡쳐가 되지 않는 문제가 있었습니다. 맵과 러닝 데이터, 그리고 경로를 합친 이미지를 구현하기 위해 아래와 같은 방법을 사용하였습니다.

### 1.지도 캡쳐

> 1차적으로 지도를 캡쳐했습니다. `MKMapSnapshotter`를 활용하여 map의 region과 size를 지정해주면 snapshot을 통해 이미지를 가져올 수 있었습니다. 
```swift
private func renderMapViewAsImage(width: Int, height: Int) {
    let options: MKMapSnapshotter.Options = .init()
    options.region = mapView.region
    options.size = CGSize(width: width, height: height)
    options.mapType = .standard
    options.showsBuildings = true
    
    let snapshotter = MKMapSnapshotter(
        options: options
    )
    snapshotter.start { snapshot, error in
       if let snapshot = snapshot {
           let renderedMapImage = snapshot.image
           ...
       } else if let error = error {
          print(error)
       }
    }
}
```

### 2. 러닝 정보 얹기

> 캡쳐한 지도위에 러닝 정보를 올립니다. 렌더한 이미지를 가지는 ZStack 아래에 runningInfo를 두어 정보를 표시합니다. 

```swfit
ZStack {
    Group {
        Group {
            Image(uiImage: renderdImage)
               ...
        .overlay {
            LinearGradient(colors: [.black.opacity(0), .black], startPoint: .center, endPoint: .bottom)
        }
        runningInfo
    }
    .offset(y: -30)
}
.frame(width: imageWidth, height: imageHeight)
```

### 3. 위도 경도를 가져와서 해당 View에 표시합니다.

> 이 부분이 가장 까다롭습니다. 아래의 프로세스를 따라 위도 경도의 좌표를 width, height를 가지는 View에 Path로 그려줍니다.

1. 해당 지도의 longitudeDelta, latitudeDelta의 값을 통해 지도의 왼쪽 상단의 좌표를 구합니다. (왼쪽 상단부터 View에서 그려주기 때문입니다.)
```swift
private func calculateCanvaDataInRect(width: Double, height: Double, region: MKCoordinateRegion) -> CanvasDataForShare {
    let minLon = region.center.longitude - region.span.longitudeDelta / 2
    let maxLat = region.center.latitude + region.span.latitudeDelta / 2
...
```

2. longitudeDelta와 현재 View의 width, latitudeDelta와 View의 height를 비교해서 해당 지도대비 해당 뷰가 가지는 상대적인 비율을 구합니다.
```swift
 let calculatedHeight = region.span.latitudeDelta * 1000000
let calculatedWidth = region.span.longitudeDelta * 1000000

let relativeWidthScale: Double = width / calculatedWidth
let relativeHeightScale: Double = height / calculatedHeight
```

3. 위도 경도를 받아와서 해당 뷰의 좌측 상단값 만큼 x,y값을 뺀 뒤, 다시 상대 비율만큼의 값을 곱해줘서 뷰에서 어떤 위치에 위치해야하는지 구합니다.
```swift
 private func calculateRelativePoint(coordinate: CLLocationCoordinate2D, canvasData: CanvasDataForShare) -> [Int] {
  let posX = Int((coordinate.longitude - canvasData.zeroX) * canvasData.widthScale * 1000000)
  let posY = Int((coordinate.latitude - canvasData.zeroY) * canvasData.heightScale * 1000000)
  return [posX, posY]
}
```

4. 구한 path 정보를 따라 이어서 Path를 그려줍니다.
```swift
for coordinate in coordinates {
    let position = calculateRelativePoint(coordinate: coordinate, canvasData: canvasData)
    path.addLine(to: CGPoint(x: position[0], y: -position[1]))
}
```

### 4. 표시한 View를 UIImage로 만들기

> UIImage와 View에 아래와 같이 Extension으로 이미지로 만드는 기능을 구현합니다

```swift
extension View {
...
  func asImage(size: CGSize) -> UIImage {
        let controller = UIHostingController(rootView: self)
        controller.view.bounds = CGRect(origin: .zero, size: size)
        let image = controller.view.asImage(size: size)
        return image
    }
}

extension UIView {
    func asImage(size: CGSize) -> UIImage {
        let format = UIGraphicsImageRendererFormat()
        format.scale = 1
        return UIGraphicsImageRenderer(size: size, format: format).image { context in
            self.drawHierarchy(in: self.layer.bounds, afterScreenUpdates: true)
        }
    }
}

```


<!-- 작업 내용 -->

<br>


## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
- 현재 CustomShareView는 정상적으로 작동되는데 다른 ShareView의 경우 비율이 맞지 않는 문제가 있습니다. 쉽게 해결될 줄 알았는데 아니어서 빠른 시일내로 동일하게 구현해야할 것 같습니다. 
```
