### PR TITLE
feature #158 : Onboarding UI 수정 및 기능 개발

### DIFF
--- a/Outline/Outline/Source/View/Onboarding/InputNicknameView.swift
+++ b/Outline/Outline/Source/View/Onboarding/InputNicknameView.swift
@@ -5,11 +5,10 @@
 //  Created by hyebin on 10/15/23.
 //
 
+import Combine
 import SwiftUI
 
 struct InputNicknameView: View {
-    @Environment(\.dismiss) private var dismiss
-//    @StateObject var dataTestViewModel = DataTestViewModel()
     @StateObject var viewModel = InputNicknameViewModel()
     
     var body: some View {
@@ -23,13 +22,14 @@ struct InputNicknameView: View {
                         .font(.title)
                         .fontWeight(.semibold)
                         .foregroundStyle(Color.customWhite)
-                        .padding(.top, 30)
+                        .padding(.top, 47)
+                        .padding(.horizontal, 16)
                     
                     Text("닉네임")
-                        .padding(.top, 43)
+                        .padding(.top, 44)
+                        .padding(.horizontal, 16)
                     
-                    TextField("", text: $viewModel.nickname,
-                              prompt: Text(viewModel.defaultNickname).foregroundStyle(Color.gray400))
+                    TextField("아웃라인메이트", text: $viewModel.nickname)
                         .foregroundStyle(Color.customWhite)
                         .padding(.vertical, 13)
                         .padding(.horizontal, 16)
@@ -40,14 +40,18 @@ struct InputNicknameView: View {
                         }
                         .padding(.top, 8)
                         .padding(.bottom, 16)
+                        .padding(.horizontal, 16)
                    
                     checkView("2자리 이상 16자리 이하", viewModel.checkInputCount)
                         .padding(.bottom, 16)
+                        .padding(.horizontal, 16)
                     
                     checkView("특수 문자 제외", viewModel.checkInputWord)
                         .padding(.bottom, 16)
+                        .padding(.horizontal, 16)
                     
                     checkView("닉네임 중복 제외", viewModel.checkNicnameDuplication)
+                        .padding(.horizontal, 16)
                     
                     CompleteButton(text: "다음", isActive: viewModel.isSuccess) {
                         if viewModel.isSuccess {
@@ -56,44 +60,26 @@ struct InputNicknameView: View {
                     }
                     .frame(maxHeight: .infinity, alignment: .bottom)
                 }
-                .padding()
             }
             .ignoresSafeArea(.keyboard)
+            .onReceive(Publishers.Merge(viewModel.keyboardWillShowPublisher, viewModel.keyboardWillHidePublisher)) { isVisible in
+                viewModel.isKeyboardVisible = isVisible
+            }
             .navigationDestination(isPresented: $viewModel.moveToInputUserInfoView) {
                 InputUserInfoView()
             }
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    dismissButton
-                }
                 ToolbarItem(placement: .topBarTrailing) {
                     doneButton
                 }
             }
         }
-        .onAppear {
-//            dataTestViewModel.readUserNameSet()
-//            viewModel.userNames = dataTestViewModel.userNameSet
-            viewModel.defaultNickname = "아웃라인메이트\(viewModel.userNames.count)"
-        }
     }
 }
 
 extension InputNicknameView {
-    private var dismissButton: some View {
-        Button {
-            dismiss()
-        } label: {
-            HStack {
-               Image(systemName: "chevron.backward")
-               Text("다시 로그인")
-            }
-            .foregroundStyle(Color.customPrimary)
-            .navigationBarBackButtonHidden(true)
-        }
-    }
     private var doneButton: some View {
-        Button("완료") {
+        Button(viewModel.isKeyboardVisible  ? "완료" : "") {
             dismissKeyboard()
         }
         .foregroundStyle(Color.customPrimary)

--- a/Outline/Outline/Source/View/Onboarding/InputUserInfoView.swift
+++ b/Outline/Outline/Source/View/Onboarding/InputUserInfoView.swift
@@ -25,55 +25,38 @@ struct InputUserInfoView: View {
                         viewModel.currentPicker = .none
                     }
                 
-                VStack(alignment: .center, spacing: 0) {
-                    Text("사용자 정보 입력")
-                        .font(.title2)
-                        .fontWeight(.semibold)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("간단한 정보를 알려주세요")
+                        .font(.title)
+                        .padding(EdgeInsets(top: 72, leading: 16, bottom: 8, trailing: 16))
                     
-                    Text("러닝 거리, 페이스, 칼로리 소모량 등\n더욱 정확한 러닝 결과를 위해 다음 정보가 필요합니다.")
-                        .multilineTextAlignment(.center)
-                        .padding(.top, 24)
+                    Text("입력하신 정보를 토대로\n더 정확한 러닝 결과를 알려드릴게요!")
+                        .font(.date)
+                        .padding(.horizontal, 16)
                     
                     listView
-                        .frame(maxHeight: .infinity)
-                        .padding(.bottom, 140)
+                    
+                    Button(action: {
+                        viewModel.defaultButtonTapped()
+                    }, label: {
+                        HStack(spacing: 0) {
+                            Image(systemName: viewModel.defaultButtonImage)
+                                .foregroundStyle(Color.customPrimary)
+                                .padding(.trailing, 12)
+                            
+                            Text("기본값 사용")
+                                .foregroundStyle(Color.gray400)
+                        }
+                    })
+                    .frame(maxWidth: .infinity, alignment: .center)
                     
                     Spacer()
                     
-                    HStack {
-                        Button(action: {
-                            viewModel.defaultButtonTapped()
-                        }, label: {
-                            Image(systemName: viewModel.defaultButtonImage)
-                                .foregroundStyle(Color.customPrimary)
-                        })
-                        
-                        Text("기본값 사용")
-                            .foregroundStyle(Color.gray400)
+                    CompleteButton(text: "완료", isActive: viewModel.isButtonActive) {
+                        viewModel.moveToLocationAuthView = true
                     }
-                    .padding(.bottom, 24)
-                    
-                    Text("정보를 입력하고 싶지 않은 경우, 기본값 사용을 선택해주세요.\n기본값을 바탕으로 러닝을 시작합니다.")
-                        .multilineTextAlignment(.center)
-                        .font(.caption)
-                        .foregroundStyle(Color.gray400)
-                        .padding(.bottom, 36)
-                    
-                    NavigationLink {
-                        OnboardingLocationAuthView()
-                    } label: {
-                        Text("완료")
-                            .foregroundStyle(Color.customBlack)
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background {
-                                RoundedRectangle(cornerRadius: 15)
-                                    .foregroundStyle(Color.customPrimary)
-                            }
-                    }
-                    .padding(.horizontal)
+                    .frame(maxHeight: .infinity, alignment: .bottom)
                 }
-                .padding(.top, 120)
                 
                 pickerView
                     .zIndex(1)
@@ -83,6 +66,9 @@ struct InputUserInfoView: View {
             .navigationBarBackButtonHidden()
             .onAppear {
                 viewModel.requestHealthAuthorization()
+            }
+            .navigationDestination(isPresented: $viewModel.moveToLocationAuthView) {
+                OnboardingLocationAuthView()
             }
         }
     }

--- a/Outline/Outline/Source/View/Onboarding/LoginView.swift
+++ b/Outline/Outline/Source/View/Onboarding/LoginView.swift
@@ -40,6 +40,7 @@ struct LoginView: View {
                         
                     NavigationLink {
                         InputNicknameView()
+                            .navigationBarBackButtonHidden()
                     } label: {
                         HStack {
                             Spacer()

--- a/Outline/Outline/Source/ViewModel/InputNicknameViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/InputNicknameViewModel.swift
@@ -5,21 +5,46 @@
 //  Created by hyebin on 10/16/23.
 //
 
+import Combine
 import SwiftUI
 
 class InputNicknameViewModel: ObservableObject {    
     @Published var nickname = ""
     @Published var checkInputCount = false
     @Published var checkInputWord = false
-    @Published var checkNicnameDuplication = true
-    @Published var moveToInputUserInfoView = false
+    @Published var checkNicnameDuplication = false
     @Published var isSuccess = false
+    @Published var moveToInputUserInfoView = false
+    @Published  var isKeyboardVisible = false
     
-    @Published var defaultNickname = "아웃라인메이트"
-    @Published var userNames = [String]()
+    private var userNameSet: [String] = []
+    
+    var keyboardWillShowPublisher: AnyPublisher<Bool, Never> {
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+            .map { _ in true }
+            .eraseToAnyPublisher()
+    }
+    
+    var keyboardWillHidePublisher: AnyPublisher<Bool, Never> {
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+            .map { _ in false }
+            .eraseToAnyPublisher()
+    }
+    
+    init() {
+        let userInfoModel = UserInfoModel()
+        userInfoModel.readUserNameSet { result in
+            switch result {
+            case .success(let userList):
+                self.userNameSet = userList
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
     
     func checkNicname() {
-//        checkDuplication()
+        checkDuplication()
         checkCount()
         checkSymbol()
         
@@ -35,7 +60,7 @@ class InputNicknameViewModel: ObservableObject {
 
 extension InputNicknameViewModel {
     private func checkDuplication() {
-        if userNames.contains(nickname) {
+        if userNameSet.contains(nickname) {
             checkNicnameDuplication = false
         } else {
             checkNicnameDuplication = true

--- a/Outline/Outline/Source/ViewModel/InputUserInfoViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/InputUserInfoViewModel.swift
@@ -28,7 +28,9 @@ class InputUserInfoViewModel: ObservableObject {
     @Published var weight = 50
     @Published var currentPicker: PickerType = .none
     @Published var isDefault = false
-    
+    @Published var isButtonActive = false
+    @Published var moveToLocationAuthView = false
+
     private var healthStore = HKHealthStore()
         
     var defaultButtonImage: String {
@@ -68,6 +70,8 @@ class InputUserInfoViewModel: ObservableObject {
             HKQuantityType.workoutType()
         ]
         
-        healthStore.requestAuthorization(toShare: quantityTypes, read: quantityTypes) {_, _ in}
+        healthStore.requestAuthorization(toShare: quantityTypes, read: quantityTypes) {_, _ in
+            self.isButtonActive = true
+        }
     }
 }


### PR DESCRIPTION
## 📌 Summary
- #158 
- UI 수정
- 닉네임 중복 검사

<br>

## ✨ Description
### 닉네임 중복검사
- `InputNicknameViewModel`이 선언될 때 Firebase에서 userNickname List를 불러옵니다.
```swift
let userInfoModel = UserInfoModel()
  userInfoModel.readUserNameSet { result in
      switch result {
      case .success(let userList):
          self.userNameSet = userList
      case .failure(let error):
          print(error)
      }
  }
```

- 닉네임이 변할 때 읽어온 닉네임 리스트에서 같은 값이 있는지 검색합니다.
```swift
private func checkDuplication() {
    if userNameSet.contains(nickname) {
        checkNicnameDuplication = false
    } else {
        checkNicnameDuplication = true
    }
}
```

### health Authorization이 아직 나타나지 않은경우 버튼 비활성화
- `requestHealthAuthorization`이 동작하면 isButtonActive를 true로 변경한다.
```swift
func requestHealthAuthorization() {
    let quantityTypes: Set = [
        HKQuantityType(.heartRate),
        HKQuantityType(.activeEnergyBurned),
        HKQuantityType(.distanceWalkingRunning),
        HKQuantityType(.stepCount),
        HKQuantityType(.cyclingCadence),
        HKQuantityType(.runningSpeed),
        HKQuantityType.workoutType()
    ]
    
    healthStore.requestAuthorization(toShare: quantityTypes, read: quantityTypes) {_, _ in
        self.isButtonActive = true
    }
}
```

- button이 viewModel의 isButtonActive의 값에 따라 active되도록 설정한다.
```swift
CompleteButton(text: "완료", isActive: viewModel.isButtonActive) {
    viewModel.moveToLocationAuthView = true
}
```


<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/55949986/dc263790-ab39-4d46-8241-8be02dd20185" width ="250">|
<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
리스트에 .bakground(Color.whte) 를 해서 확인했을 때
리스트에 자동으로 background 영역이 할당되어있어서 피그마와 같은 형태로 디자인할 수 없습니다.
리스트 저 영역을 없애는 방법아시나요? style을 plan으로하면 cornerRadius가 이상하던데....
```
