### PR TITLE
feat #163 : iOS 30초 미만 러닝 처리

### DIFF
--- a/Outline/Outline/Source/Manager/RunningDataManager.swift
+++ b/Outline/Outline/Source/Manager/RunningDataManager.swift
@@ -25,6 +25,8 @@ class RunningDataManager: ObservableObject {
     @Published var start: Date?
     @Published var end: Date?
     
+    @Published var endWithoutSaving = false
+    
     // MARK: - Private Properties
     
     private let pedometer = CMPedometer()
@@ -46,6 +48,14 @@ class RunningDataManager: ObservableObject {
         startPedometerUpdates()
     }
     
+    func stopRunningWithoutRecord() {
+        RunningEndDate = Date()
+        endWithoutSaving = true
+        Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) {_ in
+            self.endWithoutSaving = false
+        }
+    }
+ 
     func stopRunning() {
         RunningEndDate = Date()
         stopPedometerUpdates()

--- a/Outline/Outline/Source/View/Running/RunningMapView.swift
+++ b/Outline/Outline/Source/View/Running/RunningMapView.swift
@@ -12,7 +12,6 @@ struct RunningMapView: View {
     @StateObject private var viewModel = RunningMapViewModel()
     @StateObject var runningStartManager = RunningStartManager.shared
     @StateObject var runningDataManager = RunningDataManager.shared
-    
     @GestureState var isLongPressed = false
     
     @State private var moveToFinishRunningView = false
@@ -178,11 +177,18 @@ extension RunningMapView {
                                 .onEnded { _ in
                                     HapticManager.impact(style: .heavy)
                                     DispatchQueue.main.async {
-                                        checkUserLocation = false
-                                        runningDataManager.stopRunning()
-                                        runningStartManager.counter = 0
-                                        showCustomSheet = true
-                                    }
+                                       if runningStartManager.counter < 3 {
+                                           runningDataManager.stopRunningWithoutRecord()
+                                           runningStartManager.counter = 0
+                                           runningStartManager.running = false
+                                           
+                                       } else {
+                                           checkUserLocation = false
+                                           runningDataManager.stopRunning()
+                                           runningStartManager.counter = 0
+                                           showCustomSheet = true
+                                       }
+                                   }
                                 }
                         )
                     

--- a/Outline/Outline/Source/View/Running/RunningMapView.swift
+++ b/Outline/Outline/Source/View/Running/RunningMapView.swift
@@ -177,7 +177,7 @@ extension RunningMapView {
                                 .onEnded { _ in
                                     HapticManager.impact(style: .heavy)
                                     DispatchQueue.main.async {
-                                       if runningStartManager.counter < 3 {
+                                       if runningStartManager.counter < 30 {
                                            runningDataManager.stopRunningWithoutRecord()
                                            runningStartManager.counter = 0
                                            runningStartManager.running = false

--- a/Outline/Outline/Source/View/Tab/HomeTabView.swift
+++ b/Outline/Outline/Source/View/Tab/HomeTabView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct HomeTabView: View {
     @StateObject private var runningManager = RunningStartManager.shared
+    @StateObject var runningDataManager = RunningDataManager.shared
     @State private var selectedTab: Tab = .GPSArtRunning
     @State private var showDetailView = false
     
@@ -36,8 +37,13 @@ struct HomeTabView: View {
                             .ignoresSafeArea()
                     }
                 }
+                .overlay {
+                    if runningDataManager.endWithoutSaving {
+                        RunningPopup(text: "30초 이하의 러닝은 저장되지 않아요")
+                            .frame(maxHeight: .infinity, alignment: .top)
+                    }
+                }
             }
-            
             if runningManager.start {
                 CountDown(running: $runningManager.running, start: $runningManager.start)
             }
@@ -45,6 +51,7 @@ struct HomeTabView: View {
             if runningManager.running {
                 RunningView()
             }
+          
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary
#163 

<br>

## ✨ Description
### 1) `RunningDataManager`에 ` stopRunningWithoutRecord()`를 만들어서 기존의 StopRunning과 다르게 데이더 저장이 되지 않도록 따로 빼서 처리하였습니다. 
```swift
  func stopRunningWithoutRecord() {
        RunningEndDate = Date()
        endWithoutSaving = true
        Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) {_ in
            self.endWithoutSaving = false
        }
    }
```
### 2) HomeTabView로 나올 시 팝업이 상단에 뜨도록 하였습니다. 
```swift
 .overlay {
                    if runningDataManager.endWithoutSaving {
                        RunningPopup(text: "30초 이하의 러닝은 저장되지 않아요")
                            .frame(maxHeight: .infinity, alignment: .top)
                    }
                }
```



<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/76644652/3d11c856-92ee-4a87-aace-8b71f487a74f" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
RunningDataManager안에서 2초동안만 endWithoutSaving가 바뀌도록 하는게 잘 한건지 모르겠네요 ...! 더 좋은 방법이 있다면 알려주세요 !!! 
```
