### PR TITLE
fix #241 : 계정 삭제 CoreData 이슈 수정

### DIFF
--- a/Outline/Outline.xcodeproj/project.pbxproj
+++ b/Outline/Outline.xcodeproj/project.pbxproj
@@ -40,7 +40,6 @@
 		2921B00B2B012FA200533A83 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 2921B00A2B012FA200533A83 /* FirebaseFirestoreCombine-Community */; };
 		2921B00D2B012FA200533A83 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2921B00C2B012FA200533A83 /* FirebaseFirestoreSwift */; };
 		2921B00F2B01301100533A83 /* NewRunningMetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2921B00E2B01301100533A83 /* NewRunningMetricsView.swift */; };
-		2921B0112B01F39600533A83 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 2921B0102B01F39600533A83 /* Secrets.xcconfig */; };
 		2921B0132B01F3F700533A83 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2921B0122B01F3F700533A83 /* GoogleService-Info.plist */; };
 		292613172AF2BCEF00591E32 /* RecordHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292613162AF2BCEF00591E32 /* RecordHeader.swift */; };
 		2930EDBB2AF3E59F007FD141 /* ControlButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2930EDBA2AF3E59F007FD141 /* ControlButton.swift */; };
@@ -104,6 +103,7 @@
 		954CB2B82AE6492B005EB2E9 /* OnboardingLocationAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954CB2B72AE6492B005EB2E9 /* OnboardingLocationAuthView.swift */; };
 		954CB2BA2AE654BA005EB2E9 /* OnboardingNotificationAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954CB2B92AE654BA005EB2E9 /* OnboardingNotificationAuthView.swift */; };
 		954FFF782AE132D100D27537 /* CourseDataUploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954FFF772AE132D100D27537 /* CourseDataUploadManager.swift */; };
+		9572A2092B02563900E653AB /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9572A2082B02563900E653AB /* Secrets.xcconfig */; };
 		959BB20E2AEE380200B5B10B /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 959BB20D2AEE380200B5B10B /* KakaoSDKAuth */; };
 		959BB2102AEE380200B5B10B /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 959BB20F2AEE380200B5B10B /* KakaoSDKCommon */; };
 		959BB2122AEE380200B5B10B /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 959BB2112AEE380200B5B10B /* KakaoSDKUser */; };
@@ -246,7 +246,6 @@
 		2921AFFF2B012E4400533A83 /* NewRunningMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRunningMapView.swift; sourceTree = "<group>"; };
 		2921B0012B012EC800533A83 /* NewRunningNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRunningNavigationView.swift; sourceTree = "<group>"; };
 		2921B00E2B01301100533A83 /* NewRunningMetricsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRunningMetricsView.swift; sourceTree = "<group>"; };
-		2921B0102B01F39600533A83 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Secrets.xcconfig; path = ../../../Downloads/Secrets.xcconfig; sourceTree = "<group>"; };
 		2921B0122B01F3F700533A83 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		292613162AF2BCEF00591E32 /* RecordHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordHeader.swift; sourceTree = "<group>"; };
 		2930EDBA2AF3E59F007FD141 /* ControlButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlButton.swift; sourceTree = "<group>"; };
@@ -291,6 +290,7 @@
 		954CB2B72AE6492B005EB2E9 /* OnboardingLocationAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingLocationAuthView.swift; sourceTree = "<group>"; };
 		954CB2B92AE654BA005EB2E9 /* OnboardingNotificationAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNotificationAuthView.swift; sourceTree = "<group>"; };
 		954FFF772AE132D100D27537 /* CourseDataUploadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDataUploadManager.swift; sourceTree = "<group>"; };
+		9572A2082B02563900E653AB /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		959D90602ADA3A1000748BFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		95A01E162AEE3E990093D9C0 /* KakaoAuthModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAuthModel.swift; sourceTree = "<group>"; };
 		95A01E1B2AEE7A0A0093D9C0 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -648,8 +648,8 @@
 		F0AC8A902AD94C1F0061612C = {
 			isa = PBXGroup;
 			children = (
-				2921B0102B01F39600533A83 /* Secrets.xcconfig */,
 				2921B0122B01F3F700533A83 /* GoogleService-Info.plist */,
+				9572A2082B02563900E653AB /* Secrets.xcconfig */,
 				BB52392D2ADAF93D00646494 /* Outline Watch App.entitlements */,
 				BB493CEB2ADFD592009D3699 /* Outline-Watch-App-Info.plist */,
 				BB5239262ADAF70A00646494 /* Shared */,
@@ -1048,9 +1048,9 @@
 				BB1D531E2ADDBCB90073771F /* Pretendard-Thin.ttf in Resources */,
 				BB1D530C2ADDBC560073771F /* Pretendard-Black.ttf in Resources */,
 				BB1D530E2ADDBC620073771F /* Pretendard-Bold.ttf in Resources */,
+				9572A2092B02563900E653AB /* Secrets.xcconfig in Resources */,
 				BB1D53182ADDBCA20073771F /* Pretendard-Medium.ttf in Resources */,
 				BB1D53162ADDBC900073771F /* Pretendard-Light.ttf in Resources */,
-				2921B0112B01F39600533A83 /* Secrets.xcconfig in Resources */,
 				954CB2A92AE5457B005EB2E9 /* pohangDangDangRun.kml in Resources */,
 				BB1D53102ADDBC690073771F /* Pretendard-ExtraBold.ttf in Resources */,
 				BB1D531C2ADDBCB20073771F /* Pretendard-SemiBold.ttf in Resources */,
@@ -1466,7 +1466,7 @@
 		};
 		F0AC8ABE2AD94C210061612C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2921B0102B01F39600533A83 /* Secrets.xcconfig */;
+			baseConfigurationReference = 9572A2082B02563900E653AB /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1514,7 +1514,7 @@
 		};
 		F0AC8ABF2AD94C210061612C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2921B0102B01F39600533A83 /* Secrets.xcconfig */;
+			baseConfigurationReference = 9572A2082B02563900E653AB /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/Outline/Outline/Source/Model/UserData/UserDataModel.swift
+++ b/Outline/Outline/Source/Model/UserData/UserDataModel.swift
@@ -31,9 +31,11 @@ protocol UserDataModelProtocol {
 enum CoreDataError: Error {
     case saveFailed
     case dataNotFound
+    case deleteFail
 }
 
 struct UserDataModel: UserDataModelProtocol {
+    @FetchRequest (entity: CoreRunningRecord.entity(), sortDescriptors: []) var runningRecord: FetchedResults<CoreRunningRecord>
     
     let persistenceController = PersistenceController.shared
     
@@ -127,7 +129,14 @@ struct UserDataModel: UserDataModelProtocol {
     }
     
     func deleteAllRunningRecord(completion: @escaping (Result<Bool, CoreDataError>) -> Void) {
-        persistenceController.container.viewContext.reset()
-        completion(.success(true))
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "CoreRunningRecord")
+        let batchDeleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+
+        do {
+            try persistenceController.container.viewContext.execute(batchDeleteRequest)
+            completion(.success(true))
+        } catch {
+            completion(.failure(.deleteFail))
+        }
     }
 }

--- a/Outline/Outline/Source/ViewModel/ProfileViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/ProfileViewModel.swift
@@ -63,6 +63,15 @@ final class ProfileViewModel: ObservableObject {
     
     func signOut() {
         // Delete FireStoreData, CoreData
+        userDataModel.deleteAllRunningRecord { res in
+            switch res {
+            case .success(let success):
+                print("success to delete all course data \(success)")
+            case .failure(let failure):
+                print("fail to delete all course data \(failure)")
+            }
+        }
+        
         if let userId = self.userId {
             self.userInfoModel.deleteUser(uid: userId) { isSuccessDeleteDBUser in
                 switch isSuccessDeleteDBUser {

--- a/Outline/Outline/Source/ViewModel/ProfileViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/ProfileViewModel.swift
@@ -62,7 +62,6 @@ final class ProfileViewModel: ObservableObject {
     }
     
     func signOut() {
-        // Delete FireStoreData, CoreData
         userDataModel.deleteAllRunningRecord { res in
             switch res {
             case .success(let success):


### PR DESCRIPTION
## 📌 Summary
#241 
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->

<br>

## ✨ Description
> 기존 계정 삭제 시 CoreData의 기록들이 제거가 되지 않는 에러가 있었습니다. 

### UserDataModel
> 기존 UserDataModel의 deleteAllRunningRecord가 있었지만 해당 기능이 작동하지 않았습니다. 아래 코드와 같이 reset은 동작하지 않았지만 동작여부와 상관없이 completion(.success(true))가 동작하여서 정상적으로 작동한 것으로 확인되었었습니다. 
```swift
func deleteAllRunningRecord(completion: @escaping (Result<Bool, CoreDataError>) -> Void) {
    persistenceController.container.viewContext.reset()
    completion(.success(true))
}
```
> batchDeleteRequest를 사용해서 context에 execute함으로 모든 CoreRunningRecord들을 삭제할 수 있었습니다.  

```swift
func deleteAllRunningRecord(completion: @escaping (Result<Bool, CoreDataError>) -> Void) {
    let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "CoreRunningRecord")
    let batchDeleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)

    do {
        try persistenceController.container.viewContext.execute(batchDeleteRequest)
        completion(.success(true))
    } catch {
        completion(.failure(.deleteFail))
    }
}
```
<!-- 작업 내용 -->

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|계정 삭제 전|<img src = "https://github.com/BostonGosari/Outline/assets/105622985/5ef0105f-d2b3-4c1b-b7c7-a2d72ee2ea57" width ="250">|
|계정 삭제 후|<img src = "https://github.com/BostonGosari/Outline/assets/105622985/c6c01d26-0783-4682-ae64-11263a1da41d" width ="250">|

<br>


## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말 
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
result 타입에서 무지성 completion(.success())를 조심해야 할 것 같습니다. 
```
