### PR TITLE
fix #250 : Firebase 이름 변경 에러 수정

### DIFF
--- a/Outline/Outline/Source/ViewModel/ProfileViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/ProfileViewModel.swift
@@ -22,8 +22,8 @@ final class ProfileViewModel: ObservableObject {
             print("fail to userInfo updated: userId is nil")
             return
         }
-        userInfoModel.updateUserInfo(uid: userId, userInfo: userInfo) { res in
-            switch res {
+        userInfoModel.updateUserInfo(uid: userId, userInfo: userInfo) { result in
+            switch result {
             case .success(let success):
                 print("success to userInfo updated \(success)")
             case .failure(let failure):
@@ -37,8 +37,8 @@ final class ProfileViewModel: ObservableObject {
             print("fail to load userInfo: userId is nil")
             return
         }
-        userInfoModel.readUserInfo(uid: userId) { res in
-            switch res {
+        userInfoModel.readUserInfo(uid: userId) { result in
+            switch result {
             case .success(let userInfo):
                 self.userInfo = userInfo
                 print("success to load userInfo")
@@ -49,8 +49,8 @@ final class ProfileViewModel: ObservableObject {
     }
     
     func logOut() {
-        authModel.handleLogout { res in
-            switch res {
+        authModel.handleLogout { result in
+            switch result {
             case .success(let isSuccess):
                 self.authState = .logout
                 self.userId = ""
@@ -62,8 +62,8 @@ final class ProfileViewModel: ObservableObject {
     }
     
     func signOut() {
-        userDataModel.deleteAllRunningRecord { res in
-            switch res {
+        userDataModel.deleteAllRunningRecord { result in
+            switch result {
             case .success(let success):
                 print("success to delete all course data \(success)")
             case .failure(let failure):
@@ -82,8 +82,8 @@ final class ProfileViewModel: ObservableObject {
                 }
             }
         }
-        self.authModel.handleSignOut { res in
-            switch res {
+        self.authModel.handleSignOut { result in
+            switch result {
             case .success(let success):
                 print("success to sign out at authModel\(success)")
             case .failure(let failure):
@@ -91,8 +91,8 @@ final class ProfileViewModel: ObservableObject {
             }
         }
         
-        self.userInfoModel.deleteUserNameSet(userName: self.userInfo.nickname) { res in
-            switch res {
+        self.userInfoModel.deleteUserNameSet(userName: self.userInfo.nickname) { result in
+            switch result {
             case .success(let success):
                 print("success to delete userNameSet on DB \(success)")
             case .failure(let failure):

--- a/Outline/Outline/Source/ViewModel/ProfileViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/ProfileViewModel.swift
@@ -76,20 +76,18 @@ final class ProfileViewModel: ObservableObject {
                 switch isSuccessDeleteDBUser {
                 case .success(let isSuccess):
                     print("success to delete user on FireStore \(isSuccess)")
-                    if let userId = self.userId {
-                        self.authModel.handleSignOut { res in
-                            switch res {
-                            case .success(let success):
-                                print("success to sign out at authModel\(success)")
-                            case .failure(let failure):
-                                print("fail to signout at authModel \(failure)")
-                            }
-                        }
-                    }
                 case .failure(let error):
                     print("fail to delete user on FireStore")
                     print(error)
                 }
+            }
+        }
+        self.authModel.handleSignOut { res in
+            switch res {
+            case .success(let success):
+                print("success to sign out at authModel\(success)")
+            case .failure(let failure):
+                print("fail to signout at authModel \(failure)")
             }
         }
         


### PR DESCRIPTION
## 📌 Summary
#250 
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->

<br>

## ✨ Description

### 문제 상황
> 이름을 변경하였을 때 FireStore에 있는 NameSet이 변경되지 않는 에러가 있었습니다.

### 해결
> 기존에 등록한 이름이 NameSet에 등록되지 않아서 기존의 이름이 남아있는 에러였습니다. 해당 에러를 위해 기존 NameSet과 로그인된 이름을 FireStore에서 수동으로 동기화를 해주었습니다. 

### 추가 작업
> 계정 삭제시 ProfileViewModel에서 계정 삭제가 되지 않았다는 에러가 있었습니다. 해당 에러를 해결하기 위해 switch 문의 depth를 줄여서 빼줌으로 에러를 해결할 수 있었습니다.
```swift
// ProfileViewModel.swift
if let userId = self.userId {
      self.userInfoModel.deleteUser(uid: userId) { isSuccessDeleteDBUser in
          switch isSuccessDeleteDBUser {
          case .success(let isSuccess):
              print("success to delete user on FireStore \(isSuccess)")
          case .failure(let error):
              print("fail to delete user on FireStore")
              print(error)
          }
      }
  }
  self.authModel.handleSignOut { res in
      switch res {
      case .success(let success):
          print("success to sign out at authModel\(success)")
      case .failure(let failure):
          print("fail to signout at authModel \(failure)")
      }
  }
```

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
이름 변경에 대한 이슈는 다른 분들 핸드폰에서 정상적으로 작동하는 것을 확인하였습니다:)
```
