### PR TITLE
feat #278 : 자유러닝 확인 함수 구현 및 UI 수정

### DIFF
--- a/Outline/Outline/Source/Manager/RunningStartManager.swift
+++ b/Outline/Outline/Source/Manager/RunningStartManager.swift
@@ -26,6 +26,7 @@ class RunningStartManager: ObservableObject {
     private var timer: AnyCancellable?
     private var healthStore = HKHealthStore()
     private var locationManager = CLLocationManager()
+    private let userDataModel = UserDataModel()
     var startCourse: GPSArtCourse?
     var runningType: RunningType = .gpsArt
     
@@ -140,6 +141,18 @@ class RunningStartManager: ObservableObject {
         let seconds = counter % 60
         
         return String(format: "%02d:%02d", minutes, seconds)
+    }
+    
+    func getFreeRunNumber(completion: @escaping (Result<Int, CoreDataError>) -> Void) {
+        userDataModel.getFreeRunCount { result in
+            switch result {
+            case .success(let freeRunCount):
+                completion(.success(freeRunCount))
+            case .failure(let failure):
+                print("fail to read free run count \(failure)")
+                completion(.failure(.dataNotFound))
+            }
+        }
     }
 }
 

--- a/Outline/Outline/Source/Model/UserData/UserDataModel.swift
+++ b/Outline/Outline/Source/Model/UserData/UserDataModel.swift
@@ -47,6 +47,23 @@ struct UserDataModel: UserDataModelProtocol {
         }
     }
     
+    func getFreeRunCount(completion: @escaping (Result<Int, CoreDataError>) -> Void) {
+        let request = CoreRunningRecord.fetchRequest()
+        do {
+            var runningRecords = try persistenceController.container.viewContext.fetch(request)
+            var freeRunCount: Int = 0
+            for record in runningRecords {
+                if let runningType = record.runningType, runningType == "free" {
+                    freeRunCount += 1
+                }
+            }
+            completion(.success(freeRunCount))
+        } catch {
+            print("fetch Person error: \(error)")
+            completion(.failure(.dataNotFound))
+        }
+    }
+    
     func createRunningRecord(
         record: RunningRecord,
         completion: @escaping (Result<Bool, CoreDataError>) -> Void

--- a/Outline/Outline/Source/View/FreeRunning/FreeRunningHomeView.swift
+++ b/Outline/Outline/Source/View/FreeRunning/FreeRunningHomeView.swift
@@ -18,6 +18,7 @@ struct FreeRunningHomeView: View {
     @State private var showPermissionSheet = false
     @State private var isUnlocked = false
     @State private var permissionType: PermissionType = .health
+    @State private var freeRunCount: Int = 0
    
     var body: some View {
         ZStack(alignment: .top) {
@@ -52,7 +53,7 @@ struct FreeRunningHomeView: View {
                     cardView
                         .overlay {
                             VStack(alignment: .leading, spacing: 0) {
-                                Text("새로운 러닝")
+                                Text("새로운 러닝 \(freeRunCount == 0 ? "" : String(freeRunCount + 1))")
                                     .font(.customHeadline)
                                     .padding(.bottom, 8)
                                 HStack {
@@ -96,6 +97,24 @@ struct FreeRunningHomeView: View {
         }
         .onAppear {
             userLocationToString()
+            runningStartManager.getFreeRunNumber { result in
+                switch result {
+                case .success(let freeRunCount):
+                    self.freeRunCount = freeRunCount
+                case .failure(let failure):
+                    print("fail to load freeRunCount \(failure)")
+                }
+            }
+        }
+        .onChange(of: runningStartManager.complete) { _, _ in
+            runningStartManager.getFreeRunNumber { result in
+                switch result {
+                case .success(let freeRunCount):
+                    self.freeRunCount = freeRunCount
+                case .failure(let failure):
+                    print("fail to load freeRunCount \(failure)")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary
#278
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->

<br>

## ✨ Description

> freeRunningHomeView에서 '새로움 러닝 2'의 뒤에 숫자가 free run 개수입니다. 이 기능을 위해 UserDataModel에 getFreeRunCount함수를 구현하였습니다. 

### getFreeRunCount

> 다음과 같이 free런의 개수를 가져올 수 있는 함수를 구현하였습니다. 

```swift
 func getFreeRunCount(completion: @escaping (Result<Int, CoreDataError>) -> Void) {
    let request = CoreRunningRecord.fetchRequest()
    do {
        var runningRecords = try persistenceController.container.viewContext.fetch(request)
        var freeRunCount: Int = 0
        for record in runningRecords {
            if let runningType = record.runningType, runningType == "free" {
                freeRunCount += 1
            }
        }
        completion(.success(freeRunCount))
    } catch {
        print("fetch Person error: \(error)")
        completion(.failure(.dataNotFound))
    }
}
```

### FreeRunHomeView

> FreeRunningHomeView에서 startManager에 해당 함수를 가져오는 기능을 구현한 뒤 onAppear와 onChange를 통해 러닝을 시작하거나 종료했을 때 값이 업데이트 되도록 구현하였습니다.

```swift
@State private var freeRunCount: Int = 0
...
Text("새로운 러닝 \(freeRunCount == 0 ? "" : String(freeRunCount + 1))")
...
.onAppear {
    userLocationToString()
    runningStartManager.getFreeRunNumber { result in
        switch result {
        case .success(let freeRunCount):
            self.freeRunCount = freeRunCount
        case .failure(let failure):
            print("fail to load freeRunCount \(failure)")
        }
    }
}
.onChange(of: runningStartManager.complete) { _, _ in
    runningStartManager.getFreeRunNumber { result in
        switch result {
        case .success(let freeRunCount):
            self.freeRunCount = freeRunCount
        case .failure(let failure):
            print("fail to load freeRunCount \(failure)")
        }
    }
}
```

<!-- 작업 내용 -->

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|FreeRunningHomeView|<img src = "https://github.com/BostonGosari/Outline/assets/105622985/e4c182bc-e110-465e-be92-2779b3bc52f6" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
- 따로 ViewModel이 없어서 startManager에서 이 로직을 가지는 것이 가장 합리적인 것 같아서 추가했는데 괜찮을까요?
```
