### PR TITLE
fix #341 : 라이브액티비티 삭제 안되는 문제 해결

### DIFF
--- a/Outline/Outline/Source/View/NewRunning/NewRunningView.swift
+++ b/Outline/Outline/Source/View/NewRunning/NewRunningView.swift
@@ -450,9 +450,7 @@ extension NewRunningView {
                             connectivityManger.sendRunningState(.end)
                         }
                     } else {
-                        Task {
-                            await runningDataManager.removeActivity()
-                        }
+                       
                         runningDataManager.userLocations = locationManager.userLocations
                         runningStartManager.stopTimer()
                         withAnimation {
@@ -463,6 +461,10 @@ extension NewRunningView {
                             connectivityManger.sendRunningState(.end)
                         }
                     }
+                }
+                Task {
+                    print("여기옴")
+                    await runningDataManager.removeActivity()
                 }
                 showStopPopup = false
                 stopButtonScale = 1


### PR DESCRIPTION
## 📌 Summary
#341

<br>

## ✨ Description
라이브액티비티 삭제 문제를 해결하였습니다. 

<br>

아래 코드를 러닝 종료시 실행되게끔 추가하였습니다. 
```swift
Task {
    print("여기옴")
    await runningDataManager.removeActivity()
}
```


<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
이전에는 30초 이상 러닝일 경우에만 사라지도록 되어있었네요 🥲 
여기옴 ... 은 눈감아주세요 ..하하 print문 나중에 한번에 삭제하겠습니다 
```
