### PR TITLE
feat #345 : UI SE 대응

### DIFF
--- a/Outline/Outline/Source/Utils/Extension/ViewExtension.swift
+++ b/Outline/Outline/Source/Utils/Extension/ViewExtension.swift
@@ -62,6 +62,15 @@ extension View {
         controller.view.removeFromSuperview()
         return image
     }
+    
+    func getSafeArea() -> UIEdgeInsets {
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+            let window = windowScene.windows.first {
+            return window.safeAreaInsets
+        }
+        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
+
 }
 
 extension UIView {

--- a/Outline/Outline/Source/View/FininshRunning/FinishRunningView.swift
+++ b/Outline/Outline/Source/View/FininshRunning/FinishRunningView.swift
@@ -62,12 +62,12 @@ struct FinishRunningView: View {
                             }
                         }
                     )
-                    .padding(.top, 90)
+                    .padding(.top, getSafeArea().bottom == 0 ? 20 : 90)
                     Spacer()
                     CompleteButton(text: "자랑하기", isActive: true) {
                         viewModel.saveShareData()
                     }
-                    .padding(.bottom, 16)
+                    .padding(.bottom, getSafeArea().bottom == 0 ? 10 : 16)
                     
                     Button(action: {
                         withAnimation {

--- a/Outline/Outline/Source/View/GPSArtHome/CardDetailInformationView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/CardDetailInformationView.swift
@@ -114,7 +114,7 @@ struct CardDetailInformationView: View {
                     Text("\(selectedCourse.courseDuration.formatDurationInKoreanDetail())")
                         .font(.customSubbody)
                 }
-                HStack (alignment: .top) {
+                HStack(alignment: .top) {
                     LazyHStack {
                         Group {
                             Image(systemName: "star.fill")

--- a/Outline/Outline/Source/View/GPSArtHome/CardDetailInformationView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/CardDetailInformationView.swift
@@ -18,10 +18,10 @@ struct CardDetailInformationView: View {
                 .multilineTextAlignment(.leading)
                 .font(.customSubtitle2)
                 .foregroundStyle(.customWhite)
-                .padding(.vertical, 4)
                 .fixedSize(horizontal: false, vertical: true)
             
             Divider()
+                .padding(0)
             
             Text("경로 정보")
                 .font(.customSubtitle)
@@ -42,10 +42,9 @@ struct CardDetailInformationView: View {
                     }
                     .foregroundColor(.customPrimary)
                     Text("\(selectedCourse.locationInfo.locality) \(selectedCourse.locationInfo.subLocality) \(selectedCourse.locationInfo.subThroughfare)")
-                        .font(.customTag)
-                        .fontWeight(.semibold)
+                        .font(.customSubbody)
                     Text("복사")
-                        .font(.customTag)
+                        .font(.customSubbody)
                         .foregroundStyle(.gray500)
                         .onTapGesture {
                             copyLocation()
@@ -114,9 +113,10 @@ struct CardDetailInformationView: View {
                     }
                     .foregroundColor(.customPrimary)
                     Text("\(selectedCourse.courseDuration.formatDurationInKoreanDetail())")
+                        .font(.customSubbody)
                 }
-                HStack {
-                    HStack {
+                HStack (alignment: .top) {
+                    LazyHStack {
                         Group {
                             Image(systemName: "star.fill")
                                 .font(.system(size: 20))
@@ -128,12 +128,9 @@ struct CardDetailInformationView: View {
                             .fontWeight(.semibold)
                     }
                     .foregroundColor(.customPrimary)
-                    ForEach(0..<selectedCourse.hotSpots.count) { index in
-                        Text("\(selectedCourse.hotSpots[index].title)")
-                        if index != selectedCourse.hotSpots.count - 1 {
-                            Text("ˑ")
-                        }
-                    }
+                    Text(concatenateHotSpotTitles(selectedCourse.hotSpots))
+                        .font(.customSubbody)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .padding(.horizontal, 10)
@@ -186,4 +183,20 @@ struct CardDetailInformationView: View {
             self.showCopyLocationPopup = false
         }
     }
+    
+    func concatenateHotSpotTitles(_ hotSpots: [HotSpot]) -> String {
+        var result = ""
+        
+        for (index, hotSpot) in hotSpots.enumerated() {
+            result += hotSpot.title
+            if index != hotSpots.count - 1 {
+                result += " ˑ " // Add a line break if it's not the last element
+            }
+        }
+        return result
+    }
+}
+
+#Preview {
+    HomeTabView()
 }

--- a/Outline/Outline/Source/View/GPSArtHome/CardDetailView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/CardDetailView.swift
@@ -76,7 +76,7 @@ struct CardDetailView: View {
                     .gesture(isDraggable ? drag : nil)
                     
                     slideToUnlock
-                        .padding(.top, 485)
+                        .padding(.top, UIScreen.main.bounds.height * 0.68 - 95)
                         .frame(maxHeight: .infinity, alignment: .top)
                         .zIndex(1)
                     
@@ -171,7 +171,7 @@ struct CardDetailView: View {
                 .foregroundStyle(.gray400)
                 .padding(.bottom, 16)
             }
-            .padding(.top, 60)
+            .padding(.top, getSafeArea().bottom == 0 ? 30 : 60)
             .opacity(appear[0] ? 1 : 0)
             .offset(y: appear[0] ? 0 : fadeInOffset)
             
@@ -319,4 +319,8 @@ extension CardDetailView {
             }
         }
     }
+}
+
+#Preview{
+    HomeTabView()
 }

--- a/Outline/Outline/Source/View/NewRunning/NewRunningMetricsView.swift
+++ b/Outline/Outline/Source/View/NewRunning/NewRunningMetricsView.swift
@@ -41,6 +41,7 @@ struct NewRunningMetricsView: View {
                 .padding(.leading, 40)
                 Spacer()
             }
+            .offset(y: getSafeArea().bottom == 0 ? 15 : 0)
             .opacity(!isPaused && !showDetail ? 1 : 0)
         }
         .onReceive(runningManager.$counter) { newCounterValue in
@@ -100,5 +101,5 @@ struct MetricItem: View {
 }
 
 #Preview {
-    NewRunningMetricsView(showDetail: true, isPaused: true)
+    NewRunningMetricsView(showDetail: false, isPaused: true)
 }

--- a/Outline/Outline/Source/View/NewRunning/NewRunningView.swift
+++ b/Outline/Outline/Source/View/NewRunning/NewRunningView.swift
@@ -196,18 +196,22 @@ extension NewRunningView {
                 showDetailButton
             }
             .padding(.top, 26)
-            .frame(height: showDetail ? 360 + metricsTranslation : 80, alignment: .top)
+            .frame(height: showDetail ? 360 + metricsTranslation : getSafeArea().bottom == 0 ? 110 : 80, alignment: .top)
+           
             .mask {
                 RoundedRectangle(cornerRadius: 20)
+                    
             }
             .background {
                 TransparentBlurView(removeAllFilters: true)
                     .blur(radius: 6, opaque: true)
+                    .offset(y: getSafeArea().bottom == 0 ? 20 : 0)
                     .ignoresSafeArea()
                     .overlay {
                         RoundedRectangle(cornerRadius: 20)
                             .foregroundStyle(.black50)
                             .ignoresSafeArea()
+                            .offset(y: getSafeArea().bottom == 0 ? 20 : 0)
                     }
             }
             .gesture(metricsGesture)
@@ -233,6 +237,7 @@ extension NewRunningView {
                 .foregroundStyle(.gray600, .gray700)
                 .fontWeight(.semibold)
         }
+        .offset(y: getSafeArea().bottom == 0 ? 20 : 0)
     }
     
     private var controlButton: some View {
@@ -303,6 +308,7 @@ extension NewRunningView {
             .zIndex(1)
         }
         .padding(.horizontal, 90)
+        .offset(y: getSafeArea().bottom == 0 ? -10 : 0)
     }
     
     private var guideView: some View {

--- a/Outline/Outline/Source/View/Onboarding/HealthAuthView.swift
+++ b/Outline/Outline/Source/View/Onboarding/HealthAuthView.swift
@@ -27,7 +27,7 @@ struct HealthAuthView: View {
                     .font(.customSubbody)
                     .multilineTextAlignment(.center)
             }
-            .padding(.top, 100)
+            .padding(.top, getSafeArea().bottom == 0 ? 50 : 100)
             .navigationBarBackButtonHidden(true)
             .frame(maxHeight: .infinity, alignment: .top)
         }

--- a/Outline/Outline/Source/View/Onboarding/InputNicknameView.swift
+++ b/Outline/Outline/Source/View/Onboarding/InputNicknameView.swift
@@ -22,7 +22,7 @@ struct InputNicknameView: View {
                         .font(.customTitle)
                         .fontWeight(.semibold)
                         .foregroundStyle(Color.customWhite)
-                        .padding(.top, 28)
+                        .padding(.top, getSafeArea().bottom == 0 ? 20 : 47)
                         .padding(.horizontal, 16)
                     
                     Text("닉네임")
@@ -63,6 +63,7 @@ struct InputNicknameView: View {
                     .frame(maxHeight: .infinity, alignment: .bottom)
                     .padding(.bottom, 16)
                 }
+     
             }
             .ignoresSafeArea(.keyboard)
             .onReceive(Publishers.Merge(viewModel.keyboardWillShowPublisher, viewModel.keyboardWillHidePublisher)) { isVisible in
@@ -76,6 +77,7 @@ struct InputNicknameView: View {
                     doneButton
                 }
             }
+           
         }
     }
 }

--- a/Outline/Outline/Source/View/Onboarding/InputUserInfoView.swift
+++ b/Outline/Outline/Source/View/Onboarding/InputUserInfoView.swift
@@ -32,7 +32,7 @@ struct InputUserInfoView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     Text("간단한 정보를 알려주세요")
                         .font(.customTitle)
-                        .padding(EdgeInsets(top: 72, leading: 16, bottom: 8, trailing: 16))
+                        .padding(EdgeInsets(top: getSafeArea().bottom == 0 ? 50 : 72, leading: 16, bottom: 8, trailing: 16))
                     
                     Text("입력하신 정보를 토대로\n더 정확한 러닝 결과를 알려드릴게요!")
                         .font(.customDate)
@@ -40,8 +40,10 @@ struct InputUserInfoView: View {
                         .padding(.horizontal, 16)
                     
                     listView
+                        .frame(height: 217)
                         .padding(.top, 26)
-                    
+                        .padding(.bottom, 17)
+                       
                     Button(action: {
                         viewModel.defaultButtonTapped()
                         viewModel.currentPicker = .none
@@ -56,17 +58,18 @@ struct InputUserInfoView: View {
                                 .foregroundStyle(Color.gray400)
                         }
                     })
-                    .offset(y: -30)
-                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(maxWidth: .infinity)
                     
                     Spacer()
+                        .frame(maxHeight: .infinity)
                     
                     CompleteButton(text: "완료", isActive: true) {
                         viewModel.saveUserInfo(nickname: userNickName)
                         authState = .login
                     }
+                    
+                    .frame(alignment: .bottom)
                     .padding(.bottom, 16)
-                    .frame(maxHeight: .infinity, alignment: .bottom)
                 }
             }
             .foregroundStyle(Color.customWhite)

--- a/Outline/Outline/Source/View/Onboarding/LoginView.swift
+++ b/Outline/Outline/Source/View/Onboarding/LoginView.swift
@@ -92,7 +92,7 @@ struct LoginView: View {
                             .font(.customButton)
                             .fontWeight(.medium)
                     }
-                    .padding(.bottom, getSafeArea().bottom == 0 ? 100 : 0)
+                    .padding(.bottom, getSafeArea().bottom == 0 ? 100 : 40)
                 }
                 .padding(16)
             }

--- a/Outline/Outline/Source/View/Onboarding/LoginView.swift
+++ b/Outline/Outline/Source/View/Onboarding/LoginView.swift
@@ -20,7 +20,7 @@ struct LoginView: View {
                     .resizable()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .ignoresSafeArea()
-             
+                    .scaledToFill()
                 VStack(spacing: 16) {
                     Spacer()
                         
@@ -70,25 +70,6 @@ struct LoginView: View {
                             borderRectangle
                         }
                     }
-                    
-//                    NavigationLink {
-//                        InputNicknameView()
-//                           .navigationBarBackButtonHidden()
-//                    } label: {
-//                        HStack {
-//                            Spacer()
-//                            Text("시작하기")
-//                                .foregroundColor(.white)
-//                                .frame(height: 60)
-//                            Spacer()
-//                        }
-//                        .background(.ultraThinMaterial.opacity(0.9))
-//                        .cornerRadius(60)
-//                        .overlay {
-//                            borderRectangle
-//                        }
-//                    }
-
                     HStack {
                         Rectangle()
                             .frame(maxWidth: .infinity)
@@ -111,6 +92,7 @@ struct LoginView: View {
                             .font(.customButton)
                             .fontWeight(.medium)
                     }
+                    .padding(.bottom, getSafeArea().bottom == 0 ? 100 : 0)
                 }
                 .padding(16)
             }

--- a/Outline/Outline/Source/View/Profile/ProfileHealthInfoView.swift
+++ b/Outline/Outline/Source/View/Profile/ProfileHealthInfoView.swift
@@ -119,3 +119,7 @@ struct ProfileHealthInfoView: View {
         })
     }
 }
+
+#Preview{
+    ProfileHealthInfoView(height: .constant(124), weight: .constant(124))
+}

--- a/Outline/Outline/Source/View/Profile/ProfileUserInfoView.swift
+++ b/Outline/Outline/Source/View/Profile/ProfileUserInfoView.swift
@@ -181,3 +181,4 @@ struct OvalTextFieldStyle: TextFieldStyle {
             .cornerRadius(10)
     }
 }
+

--- a/Outline/Outline/Source/View/Profile/ProfileVoiceView.swift
+++ b/Outline/Outline/Source/View/Profile/ProfileVoiceView.swift
@@ -44,3 +44,7 @@ struct ProfileVoiceView: View {
         .background(Color.gray900)
     }
 }
+
+#Preview{
+    ProfileVoiceView(isVoiceOniPhone: .constant(true), isVoiceOnWatch: .constant(false))
+}

--- a/Outline/Outline/Source/View/Share/ShareView.swift
+++ b/Outline/Outline/Source/View/Share/ShareView.swift
@@ -280,3 +280,6 @@ extension View {
         return renderer.uiImage
     }
 }
+
+
+

--- a/Outline/Outline/Source/View/Tab/HomeTabView.swift
+++ b/Outline/Outline/Source/View/Tab/HomeTabView.swift
@@ -36,6 +36,7 @@ struct HomeTabView: View {
                             .frame(maxHeight: .infinity, alignment: .bottom)
                             .opacity(showDetailView ? 0 : 1)
                             .ignoresSafeArea()
+                            .offset(y: getSafeArea().bottom == 0 ? 25 : 0)
                     }
                 }
                 .sheet(isPresented: $runningManager.showPermissionSheet) {
@@ -80,4 +81,8 @@ struct HomeTabView: View {
             }
         }
     }
+}
+
+#Preview{
+    HomeTabView()
 }


### PR DESCRIPTION
## 📌 Summary
#345 

<br>

## ✨ Description
아이폰에 아래 베젤이 있든 없든 모든 ui요소가 잘 작동하게끔 반응형에 대응하였습니다! 

View extension에 getSafeArea() 함수를 만들어 아래와 같이 호출하여 사용하였습니다. 
참고로 `getSafeArea().bottom == 0` 은 아이폰 SE 혹은 아이폰 8 이전 버전입니다. (홈버튼 있는 기기) 

 `.offset(y: getSafeArea().bottom == 0 ? 20 : 0)`
` .padding(.bottom, getSafeArea().bottom == 0 ? 10 : 16)`
```swift
 func getSafeArea() -> UIEdgeInsets {
        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let window = windowScene.windows.first {
            return window.safeAreaInsets
        }
        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
    }
```

<img width="909" alt="스크린샷 2024-01-24 오후 7 57 25" src="https://github.com/BostonGosari/Outline/assets/76644652/8144246a-697e-44b6-88da-65e5d96d1604">


<br>


<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
화면이 많아 하나하나 스크린샷 넣지 못하는 점 양해 부탁드려요 ! 피그마에 모두 캡쳐해서 넣어두었으니 참고부탁드려요 ! 
```
