### PR TITLE
Feat #349 : 기록뷰 map 나타내기

### DIFF
--- a/Outline/Outline.xcodeproj/project.pbxproj
+++ b/Outline/Outline.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0E2B4CBF2AE744E8002A5103 /* RecordDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2B4CBE2AE744E8002A5103 /* RecordDetailViewModel.swift */; };
 		0E4291602B03CF3100EE75F5 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E42915F2B03CF3100EE75F5 /* LocationManager.swift */; };
 		0E4D309D2B5FC85600582E37 /* FinishRunningMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4D309C2B5FC85600582E37 /* FinishRunningMapView.swift */; };
+		0E696E942B60F39A00A4838F /* RecordMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E696E932B60F39A00A4838F /* RecordMapView.swift */; };
 		0E7EE51D2B5E6D24004F6BAF /* FreeRunningMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7EE51C2B5E6D24004F6BAF /* FreeRunningMapView.swift */; };
 		0E7EE51F2B5E761E004F6BAF /* CardDetailInformationMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7EE51E2B5E761E004F6BAF /* CardDetailInformationMapView.swift */; };
 		0E7EE5212B5E7C4B004F6BAF /* CardDetailMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7EE5202B5E7C4B004F6BAF /* CardDetailMapView.swift */; };
@@ -32,7 +33,6 @@
 		0EE92E6E2AE00AE5003192FF /* CompleteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE92E6D2AE00AE5003192FF /* CompleteButton.swift */; };
 		0EE92E7D2AE02DDC003192FF /* FreeRunningHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE92E7C2AE02DDC003192FF /* FreeRunningHomeView.swift */; };
 		0EEFA04F2B0BAC1C00C656AE /* TransparentBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEFA04E2B0BAC1C00C656AE /* TransparentBlurView.swift */; };
-		0EF5FEE42B5CEC3200D64E5E /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0EF5FEE32B5CEC3200D64E5E /* Secrets.xcconfig */; };
 		29111E372AE0C9CA009833C7 /* FinishWatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29111E362AE0C9CA009833C7 /* FinishWatchView.swift */; };
 		29111E3F2AE0CD0C009833C7 /* ConfettiWatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29111E3E2AE0CD0C009833C7 /* ConfettiWatchView.swift */; };
 		29111E952B0B8AA000CEFE00 /* NavigationTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29111E942B0B8AA000CEFE00 /* NavigationTabView.swift */; };
@@ -333,6 +333,7 @@
 		0E2B4CBE2AE744E8002A5103 /* RecordDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordDetailViewModel.swift; sourceTree = "<group>"; };
 		0E42915F2B03CF3100EE75F5 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		0E4D309C2B5FC85600582E37 /* FinishRunningMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishRunningMapView.swift; sourceTree = "<group>"; };
+		0E696E932B60F39A00A4838F /* RecordMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordMapView.swift; sourceTree = "<group>"; };
 		0E7EE51C2B5E6D24004F6BAF /* FreeRunningMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeRunningMapView.swift; sourceTree = "<group>"; };
 		0E7EE51E2B5E761E004F6BAF /* CardDetailInformationMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDetailInformationMapView.swift; sourceTree = "<group>"; };
 		0E7EE5202B5E7C4B004F6BAF /* CardDetailMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDetailMapView.swift; sourceTree = "<group>"; };
@@ -350,7 +351,6 @@
 		0EE92E6D2AE00AE5003192FF /* CompleteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteButton.swift; sourceTree = "<group>"; };
 		0EE92E7C2AE02DDC003192FF /* FreeRunningHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeRunningHomeView.swift; sourceTree = "<group>"; };
 		0EEFA04E2B0BAC1C00C656AE /* TransparentBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentBlurView.swift; sourceTree = "<group>"; };
-		0EF5FEE32B5CEC3200D64E5E /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		29111E362AE0C9CA009833C7 /* FinishWatchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishWatchView.swift; sourceTree = "<group>"; };
 		29111E3E2AE0CD0C009833C7 /* ConfettiWatchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiWatchView.swift; sourceTree = "<group>"; };
 		29111E942B0B8AA000CEFE00 /* NavigationTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTabView.swift; sourceTree = "<group>"; };
@@ -832,6 +832,7 @@
 				BB02A39B2B0D26EA00250EDD /* RecordGridView.swift */,
 				2925E0BE2B14825A0004BB05 /* NewRecordDetailView.swift */,
 				0E7EE5222B5E83E4004F6BAF /* NewRecordDetailMapView.swift */,
+				0E696E932B60F39A00A4838F /* RecordMapView.swift */,
 			);
 			path = Record;
 			sourceTree = "<group>";
@@ -1547,6 +1548,7 @@
 				2921B00F2B01301100533A83 /* NewRunningMetricsView.swift in Sources */,
 				F06298AB2AE1998D007AB2D3 /* MapInfoView.swift in Sources */,
 				95A01E352AF144030093D9C0 /* ProfileHealthInfoView.swift in Sources */,
+				0E696E942B60F39A00A4838F /* RecordMapView.swift in Sources */,
 				29EC2ED22AEB2B560033446C /* CourseAnalyzeManager.swift in Sources */,
 				29B9BB8F2B16CF780042DE19 /* DrawPathView.swift in Sources */,
 				0E1D1B292AE95AF2005282A2 /* CourseGuideView.swift in Sources */,

--- a/Outline/Outline/Source/Manager/RunningStartManager.swift
+++ b/Outline/Outline/Source/Manager/RunningStartManager.swift
@@ -139,7 +139,9 @@ class RunningStartManager: ObservableObject {
         guard let userLocation = locationManager.location?.coordinate else { return false }
         
         guard let shortestDistance = calculateShortestDistance(from: userLocation, to: ConvertCoordinateManager.convertToCLLocationCoordinates(course)) else { return false }
-        return shortestDistance <= 50
+        
+        return true
+//        return shortestDistance <= 50
     }
     
     func startTimer() {

--- a/Outline/Outline/Source/Manager/RunningStartManager.swift
+++ b/Outline/Outline/Source/Manager/RunningStartManager.swift
@@ -140,8 +140,7 @@ class RunningStartManager: ObservableObject {
         
         guard let shortestDistance = calculateShortestDistance(from: userLocation, to: ConvertCoordinateManager.convertToCLLocationCoordinates(course)) else { return false }
         
-        return true
-//        return shortestDistance <= 50
+        return shortestDistance <= 50
     }
     
     func startTimer() {

--- a/Outline/Outline/Source/Utils/Component/Card/SmallCarouselCard.swift
+++ b/Outline/Outline/Source/Utils/Component/Card/SmallCarouselCard.swift
@@ -26,7 +26,7 @@ struct SmallCarouselCard: View {
     
     var body: some View {
         ZStack(alignment: .topLeading) {
-            Image("sampleMapImage")
+            RecordMapView(userLocations: data)
                 .foregroundStyle(.ultraThinMaterial)
                 .frame(width: cardWidth - cardBorder * 2, height: cardHeight - cardBorder * 2)
                 .mask {
@@ -72,11 +72,6 @@ struct SmallCarouselCard: View {
                 }
                 .overlay(alignment: .bottom) {
                     VStack(spacing: 6) {
-                        PathGenerateManager
-                            .caculateLines(width: 200, height: 200, coordinates: data)
-                            .scale(0.5)
-                            .stroke(.customPrimary, style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
-                            .padding(.horizontal, 16)
                         Text(runName)
                             .font(.customTitle2)
                         Text(date)

--- a/Outline/Outline/Source/Utils/Component/Card/SmallListCard.swift
+++ b/Outline/Outline/Source/Utils/Component/Card/SmallListCard.swift
@@ -25,7 +25,7 @@ struct SmallListCard: View {
     
     var body: some View {
         ZStack(alignment: .topLeading) {
-            Image("sampleMapImage")
+            RecordMapView(userLocations: data)
                 .foregroundStyle(.ultraThinMaterial)
                 .frame(width: cardWidth - cardBorder * 2, height: cardHeight - cardBorder * 2)
                 .mask {
@@ -70,11 +70,6 @@ struct SmallListCard: View {
                 }
                 .overlay(alignment: .bottom) {
                     VStack(spacing: 2) {
-                        PathGenerateManager
-                            .caculateLines(width: 100, height: 100, coordinates: data)
-                            .scale(0.5)
-                            .stroke(.customPrimary, style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
-                            .padding(.horizontal, 16)
                         Text(runName)
                             .font(.customCaption)
                         Text(date)

--- a/Outline/Outline/Source/View/Record/RecordMapView.swift
+++ b/Outline/Outline/Source/View/Record/RecordMapView.swift
@@ -1,0 +1,60 @@
+//
+//  RecordMapView.swift
+//  Outline
+//
+//  Created by hyebin on 1/24/24.
+//
+
+import MapKit
+import SwiftUI
+
+struct RecordMapView: UIViewRepresentable {
+    private let mapView = MKMapView()
+    let userLocations: [CLLocationCoordinate2D]
+    
+    func makeUIView(context: Context) -> MKMapView {
+        mapView.delegate = context.coordinator
+        mapView.isZoomEnabled = false
+        mapView.isScrollEnabled = false
+        mapView.isUserInteractionEnabled = false
+
+        loadMapDataAsync()
+ 
+        return mapView
+    }
+    
+    func updateUIView(_ uiView: MKMapView, context: Context) {
+    }
+    
+    private func loadMapDataAsync() {
+        DispatchQueue.main.async {
+            let polyline = MKPolyline(coordinates: userLocations, count: userLocations.count)
+            let edgePadding = UIEdgeInsets(top: 30, left: 30, bottom: 30, right: 30)
+            mapView.setVisibleMapRect(polyline.boundingMapRect, edgePadding: edgePadding, animated: false)
+            mapView.addOverlay(polyline)
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, MKMapViewDelegate {
+        var parent: RecordMapView
+        
+        init(_ parent: RecordMapView) {
+            self.parent = parent
+        }
+        
+        func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            let renderer = MKPolylineRenderer(overlay: overlay)
+            renderer.strokeColor = .customPrimary
+            renderer.lineWidth = 4
+            return renderer
+        }
+    }
+}
+
+#Preview {
+    RecordMapView(userLocations: [])
+}

--- a/Outline/Outline/Source/View/Record/RecordMapView.swift
+++ b/Outline/Outline/Source/View/Record/RecordMapView.swift
@@ -17,7 +17,8 @@ struct RecordMapView: UIViewRepresentable {
         mapView.isZoomEnabled = false
         mapView.isScrollEnabled = false
         mapView.isUserInteractionEnabled = false
-
+        mapView.preferredConfiguration = MKStandardMapConfiguration(emphasisStyle: .muted)
+        
         loadMapDataAsync()
  
         return mapView


### PR DESCRIPTION
## 📌 Summary
- #349
- 기록뷰 map 띄우기
<br>

## ✨ Description
- SmallListCard와 SmallCarouselCard 뷰에 이미지로 지도를 띄웠던 부분으로 실제 지도로 변경했습니다.
```swift
 RecordMapView(userLocations: data)
```

- 추후 데이터가 많아질 경우 delay가 생길 경우를 대비해 map에 polyline을 그리는 부분을 비동기 처리 했습니다. 
```swift
private func loadMapDataAsync() {
    DispatchQueue.main.async {
        let polyline = MKPolyline(coordinates: userLocations, count: userLocations.count)
        let edgePadding = UIEdgeInsets(top: 30, left: 30, bottom: 30, right: 30)
        mapView.setVisibleMapRect(polyline.boundingMapRect, edgePadding: edgePadding, animated: false)
        mapView.addOverlay(polyline)
    }
}
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/55949986/29f35d4f-950a-426c-a10f-aaaea745c2cf" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
- 20개 이상의 지도를 띄웠을 때 큰 문제가 없었습니다.  하지만 더 많은 데이터를 나타낼 때 오류가 발생할 수 있어 추후 추가 테스트가 필요할거 같습니다 
```
