### PR TITLE
fix #360 : map 오류 수정

### DIFF
--- a/Outline/Outline/Source/View/NewRunning/NewRunningMapView.swift
+++ b/Outline/Outline/Source/View/NewRunning/NewRunningMapView.swift
@@ -30,6 +30,11 @@ struct NewRunningMapView: UIViewRepresentable {
         trackingButton.bottomAnchor.constraint(equalTo: mapView.layoutMarginsGuide.bottomAnchor, constant: -92).isActive = true
         
         trackingButton.backgroundColor = .black
+        
+        if let courseGuide = runningStartManager.startCourse {
+            let polyline = MKPolyline(coordinates: ConvertCoordinateManager.convertToCLLocationCoordinates(courseGuide.coursePaths), count: courseGuide.coursePaths.count)
+            mapView.addOverlay(polyline)
+        }
     
         return mapView
     }
@@ -63,7 +68,7 @@ struct NewRunningMapView: UIViewRepresentable {
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
             if let polyline = overlay as? MKPolyline {
                 let renderer = MKPolylineRenderer(polyline: polyline)
-                renderer.strokeColor = (mapView.overlays.count == 1) ? UIColor(Color.black.opacity(0.3)) : .customPrimary
+                renderer.strokeColor = (mapView.overlays.count == 1) ? UIColor(Color.black.opacity(0.5)) : .customPrimary
                 renderer.lineWidth = 5
                 return renderer
             }


### PR DESCRIPTION
## 📌 Summary
- #360 
- 맵에 가이드라인이 안나타나는 문제 해결

<br>

## ✨ Description
- 삭제되었던 polyline을 그리는 코드 추가
```swift
if let courseGuide = runningStartManager.startCourse {
    let polyline = MKPolyline(coordinates: ConvertCoordinateManager.convertToCLLocationCoordinates(courseGuide.coursePaths), count: courseGuide.coursePaths.count)
    mapView.addOverlay(polyline)
}
```

- 가이드라인이 더 잘보이도록 opacity를 0.3에서 0.5로 수정

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/55949986/95233d6a-7e95-4a0e-9fbf-7ec8fa5d437e" width ="250">|

<br>
