### PR TITLE
Fix #364 : map 오류 수정

### DIFF
--- a/Outline/Outline/Source/View/FininshRunning/FinishRunningMapView.swift
+++ b/Outline/Outline/Source/View/FininshRunning/FinishRunningMapView.swift
@@ -41,9 +41,9 @@ struct FinishRunningMapView: UIViewRepresentable {
         }
         
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-            let renderer = MKPolylineRenderer(overlay: overlay)
-            renderer.strokeColor = .customPrimary
-            //            renderer.strokeColor = Gradient(colors: [.customGradient2, .customGradient3, .customGradient3, .customGradient3, .customGradient2])
+            let renderer = MKGradientPolylineRenderer(overlay: overlay)
+            renderer.setColors([.customGradient2, .customGradient3, .customGradient3, .customGradient3, .customGradient2], locations: [])
+            renderer.lineCap = .round
             renderer.lineWidth = 8
             return renderer
         }

--- a/Outline/Outline/Source/View/FininshRunning/FinishRunningMapView.swift
+++ b/Outline/Outline/Source/View/FininshRunning/FinishRunningMapView.swift
@@ -17,6 +17,11 @@ struct FinishRunningMapView: UIViewRepresentable {
         mapView.isZoomEnabled = false
         mapView.isScrollEnabled = false
         mapView.isUserInteractionEnabled = false
+        
+        let configuration = MKStandardMapConfiguration()
+        configuration.emphasisStyle = .muted
+        configuration.pointOfInterestFilter = .init(including: [.airport, .university, .hospital, .pharmacy, .police, .library, .park])
+        mapView.preferredConfiguration = configuration
 
         let polyline = MKPolyline(coordinates: userLocations, count: userLocations.count)
         let edgePadding = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)

--- a/Outline/Outline/Source/View/GPSArtHome/CardDetailInformationMapView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/CardDetailInformationMapView.swift
@@ -44,6 +44,7 @@ struct CardDetailInformationMapView: UIViewRepresentable {
             let renderer = MKPolylineRenderer(overlay: overlay)
             renderer.strokeColor = .customPrimary
             renderer.lineWidth = 4
+            renderer.lineCap = .round
             return renderer
         }
     }

--- a/Outline/Outline/Source/View/GPSArtHome/CardDetailMapView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/CardDetailMapView.swift
@@ -56,6 +56,7 @@ struct CardDetailMapView: UIViewRepresentable {
             let renderer = MKPolylineRenderer(overlay: overlay)
             renderer.strokeColor = .customPrimary
             renderer.lineWidth = 8
+            renderer.lineCap = .round
             return renderer
         }
         

--- a/Outline/Outline/Source/View/GPSArtHome/MapInfoView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/MapInfoView.swift
@@ -49,6 +49,7 @@ struct MapInfoView: UIViewRepresentable {
                 let renderer = MKPolylineRenderer(polyline: routePolyline)
                 renderer.strokeColor = UIColor(Color.customPrimary)
                 renderer.lineWidth = 4
+                renderer.lineCap = .round
                 return renderer
             }
             return MKOverlayRenderer()

--- a/Outline/Outline/Source/View/Mirroring/MirroringMapView.swift
+++ b/Outline/Outline/Source/View/Mirroring/MirroringMapView.swift
@@ -68,8 +68,9 @@ struct MirroringMapView: UIViewRepresentable {
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
             if let polyline = overlay as? MKPolyline {
                 let renderer = MKPolylineRenderer(polyline: polyline)
-                renderer.strokeColor = (mapView.overlays.count == 1) ? UIColor(Color.black.opacity(0.3)) : .customPrimary
-                renderer.lineWidth = 5
+                renderer.strokeColor = (mapView.overlays.count == 1) ? UIColor(Color.white.opacity(0.5)) : .customPrimary
+                renderer.lineWidth = (mapView.overlays.count == 1) ? 8  : 5
+                renderer.lineCap = .round
                 return renderer
             }
             return MKOverlayRenderer(overlay: overlay)

--- a/Outline/Outline/Source/View/Mirroring/MirroringMapView.swift
+++ b/Outline/Outline/Source/View/Mirroring/MirroringMapView.swift
@@ -28,6 +28,7 @@ struct MirroringMapView: UIViewRepresentable {
         trackingButton.bottomAnchor.constraint(equalTo: mapView.layoutMarginsGuide.bottomAnchor, constant: -92).isActive = true
         
         trackingButton.backgroundColor = .black
+        trackingButton.tintColor = UIColor(.customPrimary)
         
         let course = ConvertCoordinateManager.convertToCLLocationCoordinates(connectivityManager.runningInfo.course)
         

--- a/Outline/Outline/Source/View/NewRunning/NewRunningMapView.swift
+++ b/Outline/Outline/Source/View/NewRunning/NewRunningMapView.swift
@@ -68,8 +68,9 @@ struct NewRunningMapView: UIViewRepresentable {
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
             if let polyline = overlay as? MKPolyline {
                 let renderer = MKPolylineRenderer(polyline: polyline)
-                renderer.strokeColor = (mapView.overlays.count == 1) ? UIColor(Color.black.opacity(0.5)) : .customPrimary
-                renderer.lineWidth = 5
+                renderer.strokeColor = (mapView.overlays.count == 1) ? UIColor(Color.white.opacity(0.5)) : .customPrimary
+                renderer.lineWidth = (mapView.overlays.count == 1) ? 8  : 5
+                renderer.lineCap = .round
                 return renderer
             }
             return MKOverlayRenderer(overlay: overlay)

--- a/Outline/Outline/Source/View/Record/NewRecordDetailMapView.swift
+++ b/Outline/Outline/Source/View/Record/NewRecordDetailMapView.swift
@@ -18,6 +18,11 @@ struct NewRecordDetailMapView: UIViewRepresentable {
         mapView.isScrollEnabled = false
         mapView.isUserInteractionEnabled = false
         
+        let configuration = MKStandardMapConfiguration()
+        configuration.emphasisStyle = .muted
+        configuration.pointOfInterestFilter = .init(including: [.airport, .university, .hospital, .pharmacy, .police, .library, .park])
+        mapView.preferredConfiguration = configuration
+        
         let polyline = MKPolyline(coordinates: userLocations, count: userLocations.count)
         let edgePadding = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
         mapView.setVisibleMapRect(polyline.boundingMapRect, edgePadding: edgePadding, animated: false)

--- a/Outline/Outline/Source/View/Record/NewRecordDetailMapView.swift
+++ b/Outline/Outline/Source/View/Record/NewRecordDetailMapView.swift
@@ -17,7 +17,7 @@ struct NewRecordDetailMapView: UIViewRepresentable {
         mapView.isZoomEnabled = false
         mapView.isScrollEnabled = false
         mapView.isUserInteractionEnabled = false
-
+        
         let polyline = MKPolyline(coordinates: userLocations, count: userLocations.count)
         let edgePadding = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
         mapView.setVisibleMapRect(polyline.boundingMapRect, edgePadding: edgePadding, animated: false)
@@ -41,10 +41,10 @@ struct NewRecordDetailMapView: UIViewRepresentable {
         }
         
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-            let renderer = MKPolylineRenderer(overlay: overlay)
-            renderer.strokeColor = .customPrimary
-            //            renderer.strokeColor = Gradient(colors: [.customGradient2, .customGradient3, .customGradient3, .customGradient3, .customGradient2])
+            let renderer = MKGradientPolylineRenderer(overlay: overlay)
+            renderer.setColors([.customGradient2, .customGradient3, .customGradient3, .customGradient3, .customGradient2], locations: [])
             renderer.lineWidth = 8
+            renderer.lineCap = .round
             return renderer
         }
     }

--- a/Outline/Outline/Source/View/Record/RecordMapView.swift
+++ b/Outline/Outline/Source/View/Record/RecordMapView.swift
@@ -19,6 +19,11 @@ struct RecordMapView: UIViewRepresentable {
         mapView.isUserInteractionEnabled = false
         mapView.preferredConfiguration = MKStandardMapConfiguration(emphasisStyle: .muted)
         
+        let configuration = MKStandardMapConfiguration()
+        configuration.emphasisStyle = .muted
+        configuration.pointOfInterestFilter = .init(including: [.airport, .university, .hospital, .pharmacy, .police, .library, .park])
+        mapView.preferredConfiguration = configuration
+        
         loadMapDataAsync()
  
         return mapView

--- a/Outline/Outline/Source/View/Record/RecordMapView.swift
+++ b/Outline/Outline/Source/View/Record/RecordMapView.swift
@@ -30,7 +30,7 @@ struct RecordMapView: UIViewRepresentable {
     private func loadMapDataAsync() {
         DispatchQueue.main.async {
             let polyline = MKPolyline(coordinates: userLocations, count: userLocations.count)
-            let edgePadding = UIEdgeInsets(top: 30, left: 30, bottom: 30, right: 30)
+            let edgePadding = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
             mapView.setVisibleMapRect(polyline.boundingMapRect, edgePadding: edgePadding, animated: false)
             mapView.addOverlay(polyline)
         }
@@ -48,9 +48,10 @@ struct RecordMapView: UIViewRepresentable {
         }
         
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-            let renderer = MKPolylineRenderer(overlay: overlay)
-            renderer.strokeColor = .customPrimary
-            renderer.lineWidth = 4
+            let renderer = MKGradientPolylineRenderer(overlay: overlay)
+            renderer.setColors([.customGradient2, .customGradient3, .customGradient3, .customGradient3, .customGradient2], locations: [])
+            renderer.lineWidth = 3
+            renderer.lineCap = .round
             return renderer
         }
     }

--- a/Outline/Outline/Source/View/Record/RecordView.swift
+++ b/Outline/Outline/Source/View/Record/RecordView.swift
@@ -35,7 +35,6 @@ struct RecordView: View {
                         }
                     
                     RecordHeader(scrollOffset: scrollOffset)
-                        .padding(.horizontal, 16)
                     
                     if authState == .login {
                         if filteredRecords.isEmpty {
@@ -51,9 +50,9 @@ struct RecordView: View {
                             }
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                         } else {
-                            VStack(alignment: .leading) {
+                            LazyVStack(alignment: .leading) {
                                 ScrollView(.horizontal, showsIndicators: false) {
-                                    HStack(spacing: 16) {
+                                    LazyHStack(spacing: 16) {
                                         ForEach(filteredRecords.prefix(5), id: \.id) { record in
                                             if let courseName = record.courseData?.courseName,
                                                let coursePaths = record.courseData?.coursePaths,
@@ -102,7 +101,7 @@ struct RecordView: View {
                                                 .padding(.horizontal)
                                         }
                                     }
-                                    HStack(spacing: 16) {
+                                    LazyHStack(spacing: 16) {
                                         ForEach(gpsArtRecords.prefix(3), id: \.id) { record in
                                             if let courseName = record.courseData?.courseName,
                                                let coursePaths = record.courseData?.coursePaths,
@@ -147,7 +146,7 @@ struct RecordView: View {
                                         
                                     }
                                     
-                                    HStack(spacing: 16) {
+                                    LazyHStack(spacing: 16) {
                                         ForEach(freeRecords.prefix(3), id: \.id) { record in
                                             if let courseName = record.courseData?.courseName,
                                                let coursePaths = record.courseData?.coursePaths,
@@ -179,7 +178,6 @@ struct RecordView: View {
                                 
                                 .padding(.bottom, 100)
                             }
-                            .padding(.horizontal)
                             .padding(.top, 12)
                         }
                     } else {


### PR DESCRIPTION
## 📌 Summary
- #364 
- Map 오류수정

<br>

## ✨ Description
- 가이드라인의 색을 white로 수정하고 width를 8로 수정하였습니다. 
- 라인의 모양이 둥글게 나올 수 있도록 수정했습니다.
```swift
    renderer.strokeColor = (mapView.overlays.count == 1) ? UIColor(Color.white.opacity(0.5)) : .customPrimary
    renderer.lineWidth = (mapView.overlays.count == 1) ? 8  : 5
    renderer.lineCap = .round
```

- 러닝 완료뷰와 기록뷰에 라인을 gradient line 으로 수정하였습니다.
```swift
func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
    let renderer = MKGradientPolylineRenderer(overlay: overlay)
    renderer.setColors([.customGradient2, .customGradient3, .customGradient3, .customGradient3, .customGradient2], locations: [])
    renderer.lineCap = .round
    renderer.lineWidth = 8
    return renderer
}
```

- 기록뷰에서 scroll 하는 부분에서 약간 버벅임이 발생하는 문제를 해결하기 위해 `LazyVStack`과 `LazyHStack`을 사용해 뷰가 화면에 렌더링 될 때 생성될 수 있게하여 버벅임을 줄였습니다.


<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/55949986/bffaed68-c533-44dd-a2c2-3fa6f09b4dfd" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
러닝 완료뷰와 기록뷰에서 라인이 도로명이나 건물명에 가려 깔끔하게 보이지 않는 문제를 해결하기 위해 맵에 있는 요소들을 지우려고 하였습니다. 
하지만 아무리 찾아봐도 도로명과 건물명과 같은 요소를 숨기는 방법을 찾지못했습니다..... 
방법 아시는 분 있다면 알려주시면 감사하겠습니다 ㅠㅠ
```
