### PR TITLE
fix #368: 위치 관련 보정

### DIFF
--- a/Outline/Outline.xcodeproj/project.pbxproj
+++ b/Outline/Outline.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		0E4291602B03CF3100EE75F5 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E42915F2B03CF3100EE75F5 /* LocationManager.swift */; };
 		0E4D309D2B5FC85600582E37 /* FinishRunningMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4D309C2B5FC85600582E37 /* FinishRunningMapView.swift */; };
 		0E696E942B60F39A00A4838F /* RecordMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E696E932B60F39A00A4838F /* RecordMapView.swift */; };
-		0E696E962B623A2100A4838F /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0E696E952B623A2100A4838F /* Secrets.xcconfig */; };
 		0E7EE51D2B5E6D24004F6BAF /* FreeRunningMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7EE51C2B5E6D24004F6BAF /* FreeRunningMapView.swift */; };
 		0E7EE51F2B5E761E004F6BAF /* CardDetailInformationMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7EE51E2B5E761E004F6BAF /* CardDetailInformationMapView.swift */; };
 		0E7EE5212B5E7C4B004F6BAF /* CardDetailMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7EE5202B5E7C4B004F6BAF /* CardDetailMapView.swift */; };
@@ -74,6 +73,7 @@
 		295324852AE038EE00085120 /* UserInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AC8B062AD965390061612C /* UserInfoModel.swift */; };
 		295346B82B0B5D52004F852E /* EmptyContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295346B72B0B5D52004F852E /* EmptyContentView.swift */; };
 		2955F7FA2B038084005CE2C0 /* HealthAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2955F7F92B038084005CE2C0 /* HealthAuthViewModel.swift */; };
+		296C4E732B760FF50091B925 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 296C4E722B760FF50091B925 /* Secrets.xcconfig */; };
 		2972515C2B0787640048D787 /* GuideToFreeRunningSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2972515B2B0787640048D787 /* GuideToFreeRunningSheet.swift */; };
 		2973991B2B19829A00318321 /* Outline Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 297B80FA2AE73C4500AF7219 /* Outline Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		2975F0962AE3E1790046C00B /* CornerRectangleModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2975F0952AE3E1790046C00B /* CornerRectangleModifier.swift */; };
@@ -343,7 +343,6 @@
 		0E42915F2B03CF3100EE75F5 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		0E4D309C2B5FC85600582E37 /* FinishRunningMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishRunningMapView.swift; sourceTree = "<group>"; };
 		0E696E932B60F39A00A4838F /* RecordMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordMapView.swift; sourceTree = "<group>"; };
-		0E696E952B623A2100A4838F /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Secrets.xcconfig; path = ../../../Downloads/Secrets.xcconfig; sourceTree = "<group>"; };
 		0E7EE51C2B5E6D24004F6BAF /* FreeRunningMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeRunningMapView.swift; sourceTree = "<group>"; };
 		0E7EE51E2B5E761E004F6BAF /* CardDetailInformationMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDetailInformationMapView.swift; sourceTree = "<group>"; };
 		0E7EE5202B5E7C4B004F6BAF /* CardDetailMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDetailMapView.swift; sourceTree = "<group>"; };
@@ -398,6 +397,7 @@
 		295232FB2AEEE74A0020EAFA /* ButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyle.swift; sourceTree = "<group>"; };
 		295346B72B0B5D52004F852E /* EmptyContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyContentView.swift; sourceTree = "<group>"; };
 		2955F7F92B038084005CE2C0 /* HealthAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAuthViewModel.swift; sourceTree = "<group>"; };
+		296C4E722B760FF50091B925 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		2972515B2B0787640048D787 /* GuideToFreeRunningSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideToFreeRunningSheet.swift; sourceTree = "<group>"; };
 		2975F0952AE3E1790046C00B /* CornerRectangleModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CornerRectangleModifier.swift; sourceTree = "<group>"; };
 		297B80F92AE73C4500AF7219 /* Outline.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Outline.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -945,7 +945,7 @@
 		F0AC8A902AD94C1F0061612C = {
 			isa = PBXGroup;
 			children = (
-				0E696E952B623A2100A4838F /* Secrets.xcconfig */,
+				296C4E722B760FF50091B925 /* Secrets.xcconfig */,
 				2921B0122B01F3F700533A83 /* GoogleService-Info.plist */,
 				BB52392D2ADAF93D00646494 /* Outline Watch App.entitlements */,
 				BB5239262ADAF70A00646494 /* Shared */,
@@ -1416,7 +1416,7 @@
 				29B39D442B5ECA9F00C84E6A /* DuckRun.kml in Resources */,
 				29B39D382B5E663800C84E6A /* moai.kml in Resources */,
 				954CB2AF2AE5457B005EB2E9 /* seoulCamelRun.kml in Resources */,
-				0E696E962B623A2100A4838F /* Secrets.xcconfig in Resources */,
+				296C4E732B760FF50091B925 /* Secrets.xcconfig in Resources */,
 				BB1D531E2ADDBCB90073771F /* Pretendard-Thin.ttf in Resources */,
 				0EB59A3E2B1835E600A18C50 /* alert.mp3 in Resources */,
 				BB1D530C2ADDBC560073771F /* Pretendard-Black.ttf in Resources */,
@@ -1982,7 +1982,7 @@
 		};
 		F0AC8ABE2AD94C210061612C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0E696E952B623A2100A4838F /* Secrets.xcconfig */;
+			baseConfigurationReference = 296C4E722B760FF50091B925 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -2034,7 +2034,7 @@
 		};
 		F0AC8ABF2AD94C210061612C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0E696E952B623A2100A4838F /* Secrets.xcconfig */;
+			baseConfigurationReference = 296C4E722B760FF50091B925 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/Outline/Outline/Source/Manager/LocationManager.swift
+++ b/Outline/Outline/Source/Manager/LocationManager.swift
@@ -92,10 +92,6 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             if navigationDatas != nil {
                 checkDistance(currentLocation)
             }
-            
-            if userLocations.isEmpty {
-                userLocations.append(currentLocation)
-            }
 
             if let location = manager.location {
                 let horizontalAccuracy = location.horizontalAccuracy

--- a/Outline/Outline/Source/Manager/LocationManager.swift
+++ b/Outline/Outline/Source/Manager/LocationManager.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var userLocations: [CLLocationCoordinate2D] = []
-    @Published var isRunning: Bool
+    @Published var isRunning: Bool = false
     @Published var distance = 0.0
     @Published var direction = ""
     @Published var nextDirection: (distance: Int, direction: String)?
@@ -23,13 +23,17 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     
     static let shared = LocationManager()
     
-    override init() {
+    func startUpdate() {
         isRunning = true
+        userLocations = []
         
-        super.init()
         locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
         locationManager.startUpdatingLocation()
+    }
+    
+    func stopUpdate() {
+        locationManager.stopUpdatingLocation()
     }
     
     func initNavigation() {
@@ -88,7 +92,22 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             if navigationDatas != nil {
                 checkDistance(currentLocation)
             }
-            userLocations.append(currentLocation)
+            
+            if userLocations.isEmpty {
+                userLocations.append(currentLocation)
+            }
+
+            if let location = manager.location {
+                let horizontalAccuracy = location.horizontalAccuracy
+                let verticalAccuracy = location.verticalAccuracy
+                let speed = location.speed
+                
+                print(horizontalAccuracy, verticalAccuracy, speed)
+                
+                if speed > 0.5 && horizontalAccuracy < 20 && verticalAccuracy < 20 {
+                    userLocations.append(currentLocation)
+                }
+            }
         }
     }
 }

--- a/Outline/Outline/Source/Manager/RunningDataManager.swift
+++ b/Outline/Outline/Source/Manager/RunningDataManager.swift
@@ -51,6 +51,7 @@ class RunningDataManager: ObservableObject {
     private var RunningEndDate = Date()
     
     private let runningManger = RunningStartManager.shared
+    private let locationManager = LocationManager.shared
     
     static let shared = RunningDataManager()
     
@@ -59,6 +60,7 @@ class RunningDataManager: ObservableObject {
     func startRunning() {
         RunningStartDate = Date()
         startPedometerUpdates()
+        locationManager.startUpdate()
     }
     
     func stopRunningWithoutRecord() {
@@ -72,6 +74,7 @@ class RunningDataManager: ObservableObject {
     func stopRunning() {
         RunningEndDate = Date()
         stopPedometerUpdates()
+        locationManager.stopUpdate()
     }
     
     func pauseRunning() {


### PR DESCRIPTION
## 📌 Summary
- #368 
- 위치가 튀는 버그를 잡습니다.

<br>

## ✨ Description

## 함수 생성 및 init() 삭제

### `startUpdate()`, `stopUpdate()` 함수 생성

- `locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation` 로 변경하였습니다. 가장 높은 정확도를 가지게 한다고 합니다.
- `userLocations = []` 로 변경하여 가끔 러닝 시작했을때 이미 `Polyline` 이 그려져 있는 경우가 있어 이를 해결했습니다.

<img width="918" alt="스크린샷 2024-02-09 오후 7 16 02" src="https://github.com/BostonGosari/Outline/assets/120548537/c159fdc5-8d06-40dc-9c29-8acd5f3a395d">


```swift
    func startUpdate() {
        isRunning = true
        userLocations = []
        
        locationManager.delegate = self
        locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
        locationManager.startUpdatingLocation()
    }
    
    func stopUpdate() {
        locationManager.stopUpdatingLocation()
    }
```
### 기존 init() 삭제

```swift
    override init() {
        isRunning = true
        
        super.init()
        locationManager.delegate = self
        locationManager.desiredAccuracy = kCLLocationAccuracyBest
        locationManager.startUpdatingLocation()
    }
```

## `locationManager` 함수 수정

- `horizontalAccuracy`, `verticalAccuracy`, `speed` 를 사용해 유저의 위치를 보정하였습니다.
- 아래는 `horizontalAccuracy`, `verticalAccuracy`, `speed` 를 파악하여 테스트한 결과입니다.

### 실내의 경우

- speed 가 **-1 m/s** 로 측정되며 `verticalAccuracy` **20m**, `horizontalAccuracy` **40m** 로 측정됩니다.

|구분|실내|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/120548537/27aea491-1663-42a5-9d99-b4e164eea964" width ="250">|

### 실외의 경우

- speed 가 빠른걸음 기준 **1.5 m/s** 로 측정되며 `verticalAccuracy` **10m**, `horizontalAccuracy` **14m** 로 측정됩니다.

|구분|실내|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/120548537/a124b0de-0eb2-425e-b0bc-3ff0e92ffea3" width ="250">|

### 걷다가 멈추는 경우

- `speed` 가 점점 **0m/s** 로 즉각적으로 변하는 것을 볼 수 있었습니다. (약간의 튀는 값 있음) `Accuracy` 는 변화 없음

|구분|실내|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/120548537/a250bc6c-7559-4128-a085-3ffa8b8ffb72" width ="250">|

### 결론

- `speed` 는 **성인의 평균 걸음걸이 1.3m/s** **어린이의 평균 보행속도 0.9m/s** 를 고려 (미국 건강의학포털), **느린 걸음을 고려하여 0.5 m/s** 이하인 경우 `userLocations` 에 넣지 않고, `Accuracy` 는 **20m** 보다 작아야 한다는 룰을 정했습니다. (우리나라의 경우 서울도 테스트 해봐야 겠지만 **10m**는 기본적으로 넘는 것 같습니다.

```swift
    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
        if isRunning,
           let currentLocation = locations.last?.coordinate {
            
            if navigationDatas != nil {
                checkDistance(currentLocation)
            }

            if let location = manager.location {
                let horizontalAccuracy = location.horizontalAccuracy
                let verticalAccuracy = location.verticalAccuracy
                let speed = location.speed
                
                print(horizontalAccuracy, verticalAccuracy, speed)
                
                if speed > 0.5 && horizontalAccuracy < 20 && verticalAccuracy < 20 {
                    userLocations.append(currentLocation)
                }
            }
        }
    }
```

### 번외: `DistanceFilter`

- DistanceFilter 기능이 있어 좋아했는데... **before update**… 라는 조건이 있었습니다. `distanceFilter` 의 경우 업데이트 시작전에 움직여야하는 최소 거리를 의미하는듯 합니다. 

<img width="918" alt="스크린샷 2024-02-09 오후 6 50 06" src="https://github.com/BostonGosari/Outline/assets/120548537/e0e9df39-abd5-4525-9813-3bcc01511da6">

## 추가 사항
- @moonkey48 오스틴 제가 background 가 어쩔때는 되고, 어쩔때는 안되는것 같아서 `locationManager.allowsBackgroundLocationUpdates = true` 를 해주면 된다는 것을 찾아서 간단하게 해결할 것 같아서 시도해봤는데 아무리 아래처럼 `locationManager.allowsBackgroundLocationUpdates = false` 를 해주어도 러닝을 종료해도 자꾸 위치추적하는 화살표가 아이폰 상단에 뜨게 됩니다. 이부분이 핸드폰에 무리를 줄 것 같아서 우선 뺐습니다.

```swift
    func startUpdate() {
        isRunning = true
        userLocations = []
        
        locationManager.delegate = self
        locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
        locationManager.allowsBackgroundLocationUpdates = true
        locationManager.startUpdatingLocation()
    }
    
    func stopUpdate() {
        locationManager.allowsBackgroundLocationUpdates = false
        locationManager.stopUpdatingLocation()
    }
```

- 프린트를 해보았는데 아래처럼 앱을 끄고 나서도 계속 프린트가 되는것도 확인했구요. `speed`, `accuracy` 가 계속 프린트가 됩니다.
![Feb-09-2024 22-07-42](https://github.com/BostonGosari/Outline/assets/120548537/3ed7bdad-ddb0-4283-8130-d4bd3ec06916)

- 스택 오버플로우 참고자료
   - 다 해봤는데 안됩니다. 제가 더 하면 뭔가 너무 오스틴의 범위를 침범하는것같아 중단하였습니다 (?)
<img width="664" alt="스크린샷 2024-02-09 오후 10 08 49" src="https://github.com/BostonGosari/Outline/assets/120548537/e3f0315b-9476-4cf7-b31f-6f6a61106b30">
<img width="725" alt="스크린샷 2024-02-09 오후 10 11 59" src="https://github.com/BostonGosari/Outline/assets/120548537/541e0257-ee0f-42e8-adcd-1c2944c50b06">

[스택 오버플로우 링크](https://stackoverflow.com/questions/41704302/disabling-allowsbackgroundlocationupdates-cllocationmanager-doesnt-work-after)

## 추가 필요한 수정 사항
- 혹시라도 경로가 튀었을때 (20m 도 충분히 튈수 있다고 봄) 경로를 보정해주는 알고리즘을 적용할 것인가.
- 러닝을 마치고 이어서 달리기를 선택했을때 로직 수정이 필요해보임
