### PR TITLE
fix #370 : 러닝 완료시 스코어 코어데이터 업데이트

### DIFF
--- a/Outline/Outline/Source/Manager/RunningDataManager.swift
+++ b/Outline/Outline/Source/Manager/RunningDataManager.swift
@@ -242,22 +242,30 @@ class RunningDataManager: ObservableObject {
     
     private func saveRunning() {
         guard let course = runningManger.startCourse else { return }
-        
+      
         let courseData = CourseData(courseName: course.courseName, runningLength: course.courseLength, heading: course.heading, distance: course.distance, coursePaths: userLocations, runningCourseId: "", regionDisplayName: course.regionDisplayName, score: score)
         
         let healthData = HealthData(totalTime: totalTime, averageCadence: totalSteps / totalTime * 60, totalRunningDistance: totalDistance, totalEnergy: kilocalorie, averageHeartRate: 0.0, averagePace: totalTime / totalDistance * 1000, startDate: RunningStartDate, endDate: RunningEndDate)
         
         let newRunningRecord = RunningRecord(id: UUID().uuidString, runningType: runningManger.runningType, courseData: courseData, healthData: healthData)
         
-        userDataModel.createRunningRecord(record: newRunningRecord) { result in
-            switch result {
-            case .success:
-                print("saved")
-                print(newRunningRecord)
-                self.userLocations = []
-            case .failure(let error):
-                print(error)
-            }
-        }
+        self.userDataModel.createRunningRecord(record: newRunningRecord) { result in
+               switch result {
+               case .success:
+                   self.userLocations = []
+                   
+                   // 저장 후에 스코어를 업데이트
+                   CourseScoreModel().createOrUpdateScore(courseId: course.id, score: self.score) { scoreResult in
+                       switch scoreResult {
+                       case .success:
+                           print("Score updated successfully")
+                       case .failure(let error):
+                           print("Error updating score: \(error)")
+                       }
+                   }
+               case .failure(let error):
+                   print("Error saving running record: \(error)")
+               }
+           }
     }
 }

--- a/Outline/Outline/Source/Utils/Component/ScoreStar.swift
+++ b/Outline/Outline/Source/Utils/Component/ScoreStar.swift
@@ -61,7 +61,7 @@ struct ScoreStar: View {
                     .resizable()
                     .scaledToFit()
                     .frame(height: 12 + blurSize)
-                    .offset(x: -blurSize/2, y: blurSize/2)
+                    .offset(x: -blurSize/2, y: -blurSize/2)
             }
         }
       

--- a/Outline/Outline/Source/View/GPSArtHome/BigCardView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/BigCardView.swift
@@ -86,6 +86,7 @@ struct BigCardView: View {
                     removal: .opacity.animation(.spring().delay(0.3))
                 )
             )
+           
         }
     }
     


### PR DESCRIPTION
## 📌 Summary
#370

<br>

## ✨ Description
러닝 완료시 스코어 코어데이터 업데이트합니다. 

러닝기록을 저장할 때 `CourseScoreModel()`에 만들어져있는 `createOrUpdateScore`함수를 이용하여 점수를 업데이트 합니다. 해당 함수에서는 해당 코스에 대해 스코어가 없는 경우 새로운 스코어를 추가하고, 이미 스코어가 있는 경우 주어진 값과 현재 스코어 중 큰 값을 선택합니다.

```swift 
  self.userDataModel.createRunningRecord(record: newRunningRecord) { result in
               switch result {
               case .success:
                   self.userLocations = []

                   // 저장 후에 스코어를 업데이트
                   CourseScoreModel().createOrUpdateScore(courseId: course.id, score: self.score) { scoreResult in
                       switch scoreResult {
                       case .success:
                           print("Score updated successfully")
                       case .failure(let error):
                           print("Error updating score: \(error)")
                       }
                   }
               case .failure(let error):
                   print("Error saving running record: \(error)")
               }
           }
```
<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GPSArtHomeView|<img src = "https://github.com/BostonGosari/Outline/assets/76644652/9b217abc-4993-4148-b1f0-393bd8bdf1ce" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
현재 있는 모든 기록에 대해 스코어를 한번 업데이트 하는 함수도 만들었는데 왜인지 홈에는 적용이 안되어서 .. 참 답답하네요 ㅠㅠㅠ 
추후 업데이트 해보겠습니다..! 
```
