### PR TITLE
fix #370 : 홈 카테고리 순서 정렬 로직 추가

### DIFF
--- a/Outline/Outline/Source/ViewModel/GPSArtHomeViewModel.swift
+++ b/Outline/Outline/Source/ViewModel/GPSArtHomeViewModel.swift
@@ -95,6 +95,7 @@ class GPSArtHomeViewModel: NSObject, CLLocationManagerDelegate, ObservableObject
     }
 
     func readFirstCourseList() {
+       
         courseModel.readCategoryCourse(categoryType: .category1) { result in
             switch result {
             case .success(let courseCategory):
@@ -122,6 +123,16 @@ class GPSArtHomeViewModel: NSObject, CLLocationManagerDelegate, ObservableObject
                                     }
 
                                     self.firstCourseList.append(courseWithScore)
+                                    if self.firstCourseList.count == 5 {
+                                        let sortedCourseWithScores = self.firstCourseList.sorted(by: { (course1, course2) -> Bool in
+                                            guard let index1 = courseCategory.courseIdList.firstIndex(of: course1.course.id),
+                                                  let index2 = courseCategory.courseIdList.firstIndex(of: course2.course.id) else {
+                                                return false
+                                            }
+                                            return index1 < index2
+                                        })
+                                        self.firstCourseList = sortedCourseWithScores
+                                    }
                                 case .failure(let failure):
                                     print("Failed to get score for course \(courseId): \(failure)")
                                 }
@@ -131,6 +142,7 @@ class GPSArtHomeViewModel: NSObject, CLLocationManagerDelegate, ObservableObject
                         }
                     }
                 }
+             
             case .failure(let failure):
                 print("fail to read category \(failure)")
             }
@@ -165,6 +177,16 @@ class GPSArtHomeViewModel: NSObject, CLLocationManagerDelegate, ObservableObject
                                     }
 
                                     self.secondCourseList.append(courseWithScore)
+                                    if self.secondCourseList.count == 5 {
+                                        let sortedCourseWithScores = self.secondCourseList.sorted(by: { (course1, course2) -> Bool in
+                                            guard let index1 = courseCategory.courseIdList.firstIndex(of: course1.course.id),
+                                                  let index2 = courseCategory.courseIdList.firstIndex(of: course2.course.id) else {
+                                                return false
+                                            }
+                                            return index1 < index2
+                                        })
+                                        self.secondCourseList = sortedCourseWithScores
+                                    }
                                 case .failure(let failure):
                                     print("Failed to get score for course \(courseId): \(failure)")
                                 }
@@ -208,6 +230,16 @@ class GPSArtHomeViewModel: NSObject, CLLocationManagerDelegate, ObservableObject
                                     }
 
                                     self.thirdCourseList.append(courseWithScore)
+                                    if self.thirdCourseList.count == 5 {
+                                        let sortedCourseWithScores = self.thirdCourseList.sorted(by: { (course1, course2) -> Bool in
+                                            guard let index1 = courseCategory.courseIdList.firstIndex(of: course1.course.id),
+                                                  let index2 = courseCategory.courseIdList.firstIndex(of: course2.course.id) else {
+                                                return false
+                                            }
+                                            return index1 < index2
+                                        })
+                                        self.thirdCourseList = sortedCourseWithScores
+                                    }
                                 case .failure(let failure):
                                     print("Failed to get score for course \(courseId): \(failure)")
                                 }


### PR DESCRIPTION
## 📌 Summary
#370 

<br>

## ✨ Description
기존의 각 카테고리 안의 코스들 순서가 뒤죽박죽으로 나오던 문제는 비동기 관련 문제인 것으로 파악하였습니다.
코스 5개가 카테고리에 채워지면, 원래 파베에 저장되어있는 코스 아이디들의 순서대로 재정렬하는 로직을 추가하였습니다. 

```swift
    if self.firstCourseList.count == 5 {
        let sortedCourseWithScores = self.firstCourseList.sorted(by: { (course1, course2) -> Bool in
            guard let index1 = courseCategory.courseIdList.firstIndex(of: course1.course.id),
                  let index2 = courseCategory.courseIdList.firstIndex(of: course2.course.id) else {
                return false
            }
            return index1 < index2
        })
        self.firstCourseList = sortedCourseWithScores
    }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/BostonGosari/Outline/assets/76644652/1249171f-0dcd-48b6-8c64-5c56e528bf1d" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
컨플루언스 문서에 작성된 코스 순서대로 재정렬된 것을 확인하였습니다. 
```
