### PR TITLE
Fix #384 라이브액티비티 

### DIFF
--- a/Outline/Outline/Source/Utils/Component/RunningFinishPopUp.swift
+++ b/Outline/Outline/Source/Utils/Component/RunningFinishPopUp.swift
@@ -18,6 +18,7 @@ enum ScoreState {
 
 struct RunningFinishPopUp: View {
     @StateObject private var runningStartManager = RunningStartManager.shared
+    @StateObject private var runningDataManager = RunningDataManager.shared
     @State private var counter = 0
     @State private var progress = 0.0
     @Binding var isPresented: Bool
@@ -68,6 +69,10 @@ struct RunningFinishPopUp: View {
                         runningStartManager.complete = true
                         withAnimation {
                             runningStartManager.running = false
+                        }
+                        Task {
+                            print("여기옴")
+                            await runningDataManager.removeActivity()
                         }
                     }
                     UnderlineButton(text: "조금 더 진행하기") {

--- a/Outline/Outline/Source/View/Running/RunningView.swift
+++ b/Outline/Outline/Source/View/Running/RunningView.swift
@@ -443,10 +443,7 @@ extension RunningView {
                         }
                     }
                 }
-                Task {
-                    print("여기옴")
-                    await runningDataManager.removeActivity()
-                }
+              
                 showStopPopup = false
                 stopButtonScale = 1
             }

--- a/Outline/OutlineLiveActivity/Info.plist
+++ b/Outline/OutlineLiveActivity/Info.plist
@@ -2,10 +2,55 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
+&lt;plist version="1.0"&gt;
+&lt;array&gt;
+	&lt;string&gt;Pretendard-Black.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-ExtraBold.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Bold.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-SemiBold.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Midium.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Regular.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Thin.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Light.ttf&lt;/string&gt;
+	&lt;string&gt;SFCompactDisplay-Semibold.ttf&lt;/string&gt;
+	&lt;string&gt;StretchPro.ttf&lt;/string&gt;
+&lt;/array&gt;
+&lt;/plist&gt;
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
+&lt;plist version="1.0"&gt;
+&lt;array&gt;
+	&lt;string&gt;Pretendard-Black.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-ExtraBold.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Bold.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-SemiBold.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Midium.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Regular.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Thin.ttf&lt;/string&gt;
+	&lt;string&gt;Pretendard-Light.ttf&lt;/string&gt;
+	&lt;string&gt;SFCompactDisplay-Semibold.ttf&lt;/string&gt;
+	&lt;string&gt;StretchPro.ttf&lt;/string&gt;
+&lt;/array&gt;
+&lt;/plist&gt;
+</key>
+	<string></string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Pretendard-Black.ttf</string>
+		<string>Pretendard-ExtraBold.ttf</string>
+		<string>Pretendard-Bold.ttf</string>
+		<string>Pretendard-SemiBold.ttf</string>
+		<string>Pretendard-Midium.ttf</string>
+		<string>Pretendard-Regular.ttf</string>
+		<string>Pretendard-Thin.ttf</string>
+		<string>Pretendard-Light.ttf</string>
+	</array>
 </dict>
 </plist>

--- a/Outline/OutlineLiveActivity/OutlineLiveActivity.swift
+++ b/Outline/OutlineLiveActivity/OutlineLiveActivity.swift
@@ -1,9 +1,3 @@
-//
-//  OutlineLiveActivity.swift
-//  OutlineLiveActivity
-//
-//  Created by 김하은 on 11/29/23.
-//
 import SwiftUI
 import WidgetKit
 import Intents
@@ -17,9 +11,16 @@ struct OutlineLiveActivity: Widget {
                     .background(Color.customBlack.opacity(0.7))
                     .cornerRadius(25)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 25)
+                        RoundedRectangle(cornerRadius: 24)
                         .inset(by: 0.5)
-                        .stroke(Color.customPrimary, lineWidth: 1.5)
+                        .strokeBorder(
+                            LinearGradient(
+                                gradient: Gradient(colors: [Color.customPrimary, Color.customPrimary.opacity(0)]),
+                                startPoint: .top,
+                                endPoint: .bottom
+                            ),
+                            lineWidth: 1.5
+                        )
                     )
                 VStack(spacing: 0) {
                     HStack {
@@ -44,9 +45,12 @@ struct OutlineLiveActivity: Widget {
                     }
                     .foregroundStyle(.customPrimary)
                     .padding(.top, 15)
-                    .padding(.bottom, 13)
-                    
+                
                     Divider()
+                       .background(Color.gray200)
+                       .frame(height: 1)
+                       .padding(.vertical, 6)
+                    
                     HStack {
                         Text(context.state.totalTime)
                             .font(.customWidgetData)
@@ -63,7 +67,7 @@ struct OutlineLiveActivity: Widget {
                     .fontWeight(.bold)
                     .foregroundStyle(.gray200)
                 }
-                .padding(EdgeInsets(top: 20, leading: 24, bottom: 10, trailing: 24))
+                .padding(EdgeInsets(top: 17.5, leading: 24, bottom: 10, trailing: 24))
             }
             
         } dynamicIsland: { context in
@@ -93,3 +97,5 @@ struct OutlineLiveActivity: Widget {
        
     }
 }
+
+


### PR DESCRIPTION
## 📌 Summary
#384 

<br>

## ✨ Description
1. 라이브액티비티 UI 수정
- 폰트 수정 : 이전에 폰트가 적용되지 않았던 문제를 해결했습니다. 당시 타겟 멤버십은 지정했지만 라이브액티비티 내의 Info.plist 에 폰트 목록을 추가하지 않았던게 문제였습니다. 
- UI 디테일 수정 : 그레디언트가 적용된 상단 테두리, padding 등 디테일을 수정했습니다. 

2. 러닝 정지 시 라이브액티비티 
기존에 정지 버튼을 누르면 라이브액티비티가 삭제되었었는데, 이는 러닝을 종료했더라도 조금 더 달리기를 누를 경우를 고려하지 못한 플로우였습니다. 그래서 라이브액티비티 삭제하는 다음 코드를 결과페이지로 이동하는 부분으로 이동시켰습니다. 
```
Task {
    await runningDataManager.removeActivity()
}
```


<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|UI 수정|<img src = "https://github.com/user-attachments/assets/305c41dc-72aa-425a-bf04-39b3cafb9349" width ="250">|


<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
LiveActivity 의 최대 Height 가 정해져있어서 Figma의 디자인은 구현 불가능하여 위쪽에 그라데이션으로 테두리를 넣는 것과 세부 Padding을 포기했었는데, 이번에 임의로(?) 시각보정을 해보았습니다.. 
```
