### PR TITLE
Fix #383 : 러닝 경로 보정 알고리즘 구현

### DIFF
--- a/Outline/Outline Watch/Source/View/MapWatchView.swift
+++ b/Outline/Outline Watch/Source/View/MapWatchView.swift
@@ -31,7 +31,9 @@ struct MapWatchView: View {
                 }
                 
                 if !userLocations.isEmpty {
-                    MapPolyline(coordinates: userLocations)
+                    let smoothedLocation = smoothLocations(userLocations)
+                    
+                    MapPolyline(coordinates: smoothedLocation)
                         .stroke(.customPrimary, style: StrokeStyle(lineWidth: 5, lineCap: .round, lineJoin: .round))
                 }
             }
@@ -115,5 +117,24 @@ struct MapWatchView: View {
         }
         
         return maxDistance
+    }
+    
+    private func smoothLocations(_ locations: [CLLocationCoordinate2D]) -> [CLLocationCoordinate2D] {
+        guard locations.count > 1 else { return locations }
+       
+        var smoothed: [CLLocationCoordinate2D] = []
+        
+        for i in 0..<locations.count {
+            let start = max(0, i - 2)
+            let end = min(locations.count - 1, i + 2)
+            let subset = Array(locations[start...end])
+            
+            let avgLatitude = subset.map { $0.latitude }.reduce(0, +) / Double(subset.count)
+            let avgLongitude = subset.map { $0.longitude }.reduce(0, +) / Double(subset.count)
+            
+            smoothed.append(CLLocationCoordinate2D(latitude: avgLatitude, longitude: avgLongitude))
+        }
+        
+        return smoothed
     }
 }

--- a/Outline/Outline Watch/Source/View/MirroringView/MirroringMapWatchView.swift
+++ b/Outline/Outline Watch/Source/View/MirroringView/MirroringMapWatchView.swift
@@ -27,7 +27,8 @@ struct MirroringMapWatchView: View {
                 }
                 
                 if !connectivityManager.runningData.userLocations.isEmpty {
-                    MapPolyline(coordinates: connectivityManager.runningData.userLocations.toCLLocationCoordinates())
+                    let smoothedLocation = smoothLocations(connectivityManager.runningData.userLocations.toCLLocationCoordinates())
+                    MapPolyline(coordinates: smoothedLocation)
                         .stroke(.customPrimary, style: StrokeStyle(lineWidth: 5, lineCap: .round, lineJoin: .round))
                 }
             }
@@ -107,6 +108,25 @@ struct MirroringMapWatchView: View {
         }
         
         return maxDistance
+    }
+    
+    private func smoothLocations(_ locations: [CLLocationCoordinate2D]) -> [CLLocationCoordinate2D] {
+        guard locations.count > 1 else { return locations }
+       
+        var smoothed: [CLLocationCoordinate2D] = []
+        
+        for i in 0..<locations.count {
+            let start = max(0, i - 2)
+            let end = min(locations.count - 1, i + 2)
+            let subset = Array(locations[start...end])
+            
+            let avgLatitude = subset.map { $0.latitude }.reduce(0, +) / Double(subset.count)
+            let avgLongitude = subset.map { $0.longitude }.reduce(0, +) / Double(subset.count)
+            
+            smoothed.append(CLLocationCoordinate2D(latitude: avgLatitude, longitude: avgLongitude))
+        }
+        
+        return smoothed
     }
 }
 

--- a/Outline/Outline/Source/View/Mirroring/MirroringMapView.swift
+++ b/Outline/Outline/Source/View/Mirroring/MirroringMapView.swift
@@ -40,19 +40,38 @@ struct MirroringMapView: UIViewRepresentable {
     
     func updateUIView(_ uiView: MKMapView, context: Context) {
         let userLocations = ConvertCoordinateManager.convertToCLLocationCoordinates(connectivityManager.runningData.userLocations)
+        let smoothedLocations = smoothLocations(userLocations)
         
         if uiView.overlays.count >= 2,
            let overlay = uiView.overlays.last {
             uiView.removeOverlay(overlay)
         }
         
-        if !userLocations.isEmpty {
+        if !smoothedLocations.isEmpty {
             let polyline = MKPolyline(
-                coordinates: userLocations,
-                count: userLocations.count
+                coordinates: smoothedLocations,
+                count: smoothedLocations.count
             )
             uiView.addOverlay(polyline)
         }
+    }
+    
+    private func smoothLocations(_ locations: [CLLocationCoordinate2D]) -> [CLLocationCoordinate2D] {
+        guard locations.count > 1 else { return locations }
+        
+        var smoothed: [CLLocationCoordinate2D] = []
+        for i in 0..<locations.count {
+            let start = max(0, i - 2)
+            let end = min(locations.count - 1, i + 2)
+            let subset = Array(locations[start...end])
+            
+            let avgLatitude = subset.map { $0.latitude }.reduce(0, +) / Double(subset.count)
+            let avgLongitude = subset.map { $0.longitude }.reduce(0, +) / Double(subset.count)
+            
+            smoothed.append(CLLocationCoordinate2D(latitude: avgLatitude, longitude: avgLongitude))
+        }
+        
+        return smoothed
     }
     
     func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
## 📌 Summary
- #383 
- 러닝 경로 보정 알고리즘 구현

<br>

## ✨ Description
polyline을 보정하는 방법에 대해 조사하면서 `Smoothening Algorithm`에 대해 알게되었습니다.
현재 좌표들을 smoothing 하는 알고리즘을 적용하여, 불규칙한 경로를 매끄럽게 만들 수 있습니다. 
다양한 방법들 중 이동 평균 방법을 사용하기로 하였습니다.
- 구현이 간단하고, 계산이 빨라 실시간 데이터 처리에 적합
- 불규칙한 데이터의 노이즈를 줄이는 데 효과적
(by. chatGPT)

<br>

- 따라서 다음과 같이 알고리즘을 구현하였습니다.
- 각 위치에 대해 최대 4개의 점들의 평균을 계산하여 현재 점을 smoothing 합니다.
```swift
private func smoothLocations(_ locations: [CLLocationCoordinate2D]) -> [CLLocationCoordinate2D] {
    guard locations.count > 1 else { return locations }
    
    var smoothed: [CLLocationCoordinate2D] = []
    for i in 0..<locations.count {
        let start = max(0, i - 2) // 이전 2개 점
        let end = min(locations.count - 1, i + 2) // 다음 2개 점
        let subset = Array(locations[start...end])
        
        let avgLatitude = subset.map { $0.latitude }.reduce(0, +) / Double(subset.count)
        let avgLongitude = subset.map { $0.longitude }.reduce(0, +) / Double(subset.count)
        
        smoothed.append(CLLocationCoordinate2D(latitude: avgLatitude, longitude: avgLongitude))
    }
    
    return smoothed
}
```
<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|걷기|<img src = "https://github.com/user-attachments/assets/a0cd7290-61d4-40b0-9b68-2ca9ffccf80f" width ="250">|걷기2|<img src = "https://github.com/user-attachments/assets/eb5a756c-6456-41e2-955c-503232d3c6a8" width ="250">
|버스1|<img src = "https://github.com/user-attachments/assets/498d4d16-36e0-4346-8627-87ce2d3e45c9" width ="250">|버스2|<img src = "https://github.com/user-attachments/assets/0f5c805c-d8d3-4722-b63a-b736aef0797f" width ="250">

위의 빨간 선은 기존의 코드를 사용하여 polyline을 그린 경우이고, 밑에 초록 선은 Smoothening Algorithm을 적용한 경우 입니다.

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
이 곳에서 리뷰포인트를 작성해주세요.
```
