### PR TITLE
fix #384 : 라이브액티비티 워치에서 비활성화

### DIFF
--- a/Outline/OutlineLiveActivity/OutlineLiveActivity.swift
+++ b/Outline/OutlineLiveActivity/OutlineLiveActivity.swift
@@ -4,6 +4,7 @@ import Intents
 
 struct OutlineLiveActivity: Widget {
     var body: some WidgetConfiguration {
+        #if !os(watchOS)
         ActivityConfiguration(for: RunningAttributes.self) { context in
             ZStack {
                 Rectangle()
@@ -83,7 +84,7 @@ struct OutlineLiveActivity: Widget {
                    
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    Text(context.state.totalTime)
+             
                 }
             } compactLeading: {
           
@@ -94,6 +95,6 @@ struct OutlineLiveActivity: Widget {
             }
            
         }
-       
+        #endif
     }
 }


### PR DESCRIPTION
## 📌 Summary
#384 

<br>

## ✨ Description
watchOS 에서의 까만 창이 뜨는 문제를 해결합니다. 

<br>


<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
딱히 리뷰할게 없을 것으로 판단되어 바로 머지하겠습니다. 
```
