### PR TITLE
Fix #389 : 러닝 완료 후 별 적용 오류 해결

### DIFF
--- a/Outline/Outline/Source/Manager/RunningDataManager.swift
+++ b/Outline/Outline/Source/Manager/RunningDataManager.swift
@@ -39,6 +39,8 @@ class RunningDataManager: ObservableObject {
     @Published var score: Int = 0
     @Published var num: Int = 0
     
+    @Published var isSaveNewScore = false
+    
     @MainActor @Published private(set) var activityID: String?
     @MainActor @Published private(set) var activityToken: String?
     
@@ -246,6 +248,7 @@ class RunningDataManager: ObservableObject {
                    CourseScoreModel().createOrUpdateScore(courseId: course.id, score: self.score) { scoreResult in
                        switch scoreResult {
                        case .success:
+                           self.isSaveNewScore = true
                            print("Score updated successfully")
                        case .failure(let error):
                            print("Error updating score: \(error)")

--- a/Outline/Outline/Source/View/GPSArtHome/GPSArtHomeView.swift
+++ b/Outline/Outline/Source/View/GPSArtHome/GPSArtHomeView.swift
@@ -23,6 +23,7 @@ struct GPSArtHomeView: View {
     
     // 받아오는 변수
     @Binding var showDetailView: Bool
+    @Binding var isReloadScore: Bool
     @Namespace private var namespace
     
     let indexWidth: CGFloat = 25
@@ -148,6 +149,12 @@ struct GPSArtHomeView: View {
                 }
                 .refreshable {
                     viewModel.getAllCoursesFromFirebase()
+                }
+                .onChange(of: isReloadScore) { _, newValue in
+                    if newValue {
+                        viewModel.getAllCoursesFromFirebase()
+                        isReloadScore = false
+                    }
                 }
             }
             if let selectedCourse, showDetailView {

--- a/Outline/Outline/Source/View/Tab/HomeTabView.swift
+++ b/Outline/Outline/Source/View/Tab/HomeTabView.swift
@@ -26,7 +26,7 @@ struct HomeTabView: View {
                             case .freeRunning:
                                 FreeRunningHomeView()
                             case .GPSArtRunning:
-                                GPSArtHomeView(showDetailView: $showDetailView)
+                                GPSArtHomeView(showDetailView: $showDetailView, isReloadScore: $runningDataManager.isSaveNewScore)
                             case .myRecord:
                                 RecordView()
                             }


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- #389 

<br>

## ✨ Description
<!-- 작업 내용 -->
- 러닝 완료 후 별이 적용되지 않는 오류를 해결했습니다.
- 확인 결과 별 적용이 완전히 안되는 것은 아니고, 앱을 종료 후 재 실행했을 때만 데이터가 reload 되어 러닝 종료 후 바로 적용되지 않아 발생하는 문제였습니다.
- 러닝 완료 후 정상적으로 점수가 update 되었다면 `isSaveNewScore`를 true로 변경하여, `GPSArtHomeView`에서 데이터를 reload 하도록 구현하였습니다.
```swift
.onChange(of: isReloadScore) { _, newValue in
      if newValue {
          viewModel.getAllCoursesFromFirebase()
          isReloadScore = false
      }
  }
```
<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/563ea641-a507-4945-a134-c37e4511de4c" width ="250">|
- score를 51로 테스트 했습니다.
- 러닝이 종료된 후 "런런"에 별 2개가 적용된것을 확인할 수 있습니다.
<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
이 곳에서 리뷰포인트를 작성해주세요.
```
